### PR TITLE
Reduced random crit chance and random damage spread to match modern TF2, fixed a bug with tf_weapon_criticals

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -2857,8 +2857,8 @@ int CTFPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 			}
 			else
 			{
-				float flMin = 0.25;
-				float flMax = 0.75;
+				float flMin = 0.40;
+				float flMax = 0.60;
 				float flCenter = 0.5;
 
 				if ( bitsDamage & DMG_USEDISTANCEMOD )
@@ -2875,8 +2875,8 @@ int CTFPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 							flCenter = RemapVal( flCenter, 0.5, 1.0, 0.5, 0.65 );
 						}
 					}
-					flMin = max( 0.0, flCenter - 0.25 );
-					flMax = min( 1.0, flCenter + 0.25 );
+					flMin = max( 0.0, flCenter - 0.10 );
+					flMax = min( 1.0, flCenter + 0.10 );
 
 					if ( bDebug )
 					{

--- a/src/game/shared/tf/tf_shareddefs.h
+++ b/src/game/shared/tf/tf_shareddefs.h
@@ -1,4 +1,4 @@
-//====== Copyright © 1996-2006, Valve Corporation, All rights reserved. =======
+//====== Copyright Â© 1996-2006, Valve Corporation, All rights reserved. =======
 //
 // Purpose: 
 //
@@ -55,15 +55,15 @@ enum
 //-----------------------------------------------------------------------------
 // CVar replacements
 //-----------------------------------------------------------------------------
-#define TF_DAMAGE_CRIT_CHANCE				0.05f
-#define TF_DAMAGE_CRIT_CHANCE_RAPID			0.05f
+#define TF_DAMAGE_CRIT_CHANCE				0.02f
+#define TF_DAMAGE_CRIT_CHANCE_RAPID			0.02f
 #define TF_DAMAGE_CRIT_DURATION_RAPID		2.0f
-#define TF_DAMAGE_CRIT_CHANCE_MELEE			0.15f
+#define TF_DAMAGE_CRIT_CHANCE_MELEE			0.10f
 
 #define TF_DAMAGE_CRITMOD_MAXTIME			20
 #define TF_DAMAGE_CRITMOD_MINTIME			2
 #define TF_DAMAGE_CRITMOD_DAMAGE			800
-#define TF_DAMAGE_CRITMOD_MAXMULT			4
+#define TF_DAMAGE_CRITMOD_MAXMULT			6
 
 #define TF_DAMAGE_CRIT_MULTIPLIER			3.0f
 

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -468,12 +468,6 @@ void CTFWeaponBase::CalcIsAttackCritical( void)
 	if ( gpGlobals->framecount == m_iLastCritCheckFrame )
 		return;
 
-	if (!tf_weapon_criticals.GetBool() && (!IsMeleeWeapon() || (IsMeleeWeapon() && tf_weapon_criticals_melee.GetInt() == 1)))
-	{
-		m_bCurrentAttackIsCrit = false;
-		return;
-	}
-
 	m_iLastCritCheckFrame = gpGlobals->framecount;
 
 	// if base entity seed has changed since last calculation, reseed with new seed
@@ -488,10 +482,14 @@ void CTFWeaponBase::CalcIsAttackCritical( void)
 	{
 		m_bCurrentAttackIsCrit = true;
 	}
-	else
+	else if (!tf_weapon_criticals.GetBool() && (!IsMeleeWeapon() || (IsMeleeWeapon() && tf_weapon_criticals_melee.GetInt() == 1)))
 	{
 		// call the weapon-specific helper method
 		m_bCurrentAttackIsCrit = CalcIsAttackCriticalHelper();
+	}
+	else
+	{
+		m_bCurrentAttackIsCrit = false;
 	}
 }
 


### PR DESCRIPTION
Random distance variation for damage spread goes down from 25% to 10%.
Crit chance goes down from 5-20% to 2-12%.

Also fixed weapons not critting after round win if random crits are disabled. Remember, tf_weapon_criticals check MUST remain at the very end of CalcIsAttackCritical function.