### PR TITLE
Fixed ammo pickup sound always playing

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -4545,7 +4545,7 @@ int CTFPlayer::GiveAmmo( int iCount, int iAmmoIndex, bool bSuppressSound )
 		EmitSound( "BaseCombatCharacter.AmmoPickup" );
 	}
 
-	CBaseCombatCharacter::GiveAmmo( iAdd, iAmmoIndex );
+	CBaseCombatCharacter::GiveAmmo( iAdd, iAmmoIndex, bSuppressSound );
 	return iAdd;
 }
 

--- a/src/game/shared/tf/tf_viewmodel.h
+++ b/src/game/shared/tf/tf_viewmodel.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright Â© 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //
@@ -38,8 +38,9 @@ public:
 #if defined( CLIENT_DLL )
 	virtual bool ShouldPredict( void )
 	{
+		// Prediction often causes viewmodels to get bugged so I'm disabling this for now. (Nickine)
 		if ( GetOwner() && GetOwner() == C_BasePlayer::GetLocalPlayer() )
-			return true;
+			return false;
 
 		return BaseClass::ShouldPredict();
 	}


### PR DESCRIPTION
Fixed BaseCombatCharacter.AmmoPickup sound always playing when player receives ammo regardless of bSupressSound value.