### PR TITLE
Enable Sudden Death by default.

### DIFF
--- a/src/game/shared/teamplayroundbased_gamerules.cpp
+++ b/src/game/shared/teamplayroundbased_gamerules.cpp
@@ -208,7 +208,7 @@ ConVar mp_restartround( "mp_restartround", "0", FCVAR_GAMEDLL, "If non-zero, the
 ConVar mp_stalemate_timelimit( "mp_stalemate_timelimit", "240", FCVAR_REPLICATED, "Timelimit (in seconds) of the stalemate round." );
 ConVar mp_autoteambalance( "mp_autoteambalance", "1", FCVAR_NOTIFY );
 
-ConVar mp_stalemate_enable( "mp_stalemate_enable", "0", FCVAR_NOTIFY, "Enable/Disable stalemate mode." );
+ConVar mp_stalemate_enable( "mp_stalemate_enable", "1", FCVAR_NOTIFY, "Enable/Disable stalemate mode." );
 ConVar mp_match_end_at_timelimit( "mp_match_end_at_timelimit", "0", FCVAR_NOTIFY, "Allow the match to end when mp_timelimit hits instead of waiting for the end of the current round." );
 
 ConVar mp_holiday_nogifts( "mp_holiday_nogifts", "0", FCVAR_NOTIFY, "Set to 1 to prevent holiday gifts from spawning when players are killed." );


### PR DESCRIPTION
I'm fairly certain the console versions of TF2 have this enabled, it's turned off on PC for some reason. Anyway, this would help make stalemates on CTF/TC/5CP more interesting.