### PR TITLE
VM Rotation Fix

### DIFF
--- a/src/game/client/view.cpp
+++ b/src/game/client/view.cpp
@@ -736,7 +736,7 @@ void CViewRender::SetUpViews()
 	float flFOVOffset = fDefaultFov - view.fov;
 
 	//Adjust the viewmodel's FOV to move with any FOV offsets on the viewer's end
-	view.fovViewmodel = g_pClientMode->GetViewModelFOV() - flFOVOffset;
+	m_View.fovViewmodel = abs(g_pClientMode->GetViewModelFOV() - flFOVOffset);
 
 	if ( UseVR() )
 	{


### PR DESCRIPTION
Stopping viewmodels from getting rotated when zooming.
Affects:
TF2: SniperRifle, Poachers Pride
HL2: Crossbow