### PR TITLE
Buildings spawned by ent_create go active instantly

### DIFF
--- a/src/game/server/tf/tf_gamestats.cpp
+++ b/src/game/server/tf/tf_gamestats.cpp
@@ -567,6 +567,12 @@ void CTFGameStats::Event_PlayerDamage( CBasePlayer *pBasePlayer, const CTakeDama
 			return;
 
 		pAttacker = pSentry->GetOwner();
+		if ( !pAttacker )
+		{
+			// Sentry with no builder? Must be a pre-placed sentry.
+			// It's easier to just cut off here and don't count damage.
+			return;
+		}
 	}
 	// don't count damage to yourself
 	if ( pTarget == pAttacker )

--- a/src/game/server/tf/tf_obj.cpp
+++ b/src/game/server/tf/tf_obj.cpp
@@ -620,6 +620,13 @@ CTFPlayer *CBaseObject::GetOwner()
 void CBaseObject::Activate( void )
 {
 	BaseClass::Activate();
+	
+	// This only ever gets called if a building is spawned in a non-standard way.
+	// So just go through all contruction phases rapidly.
+	StartPlacement( NULL );
+	StartBuilding( NULL );
+	SetHealth( GetMaxHealth() );
+	FinishedBuilding();
 
 	Assert( 0 );
 }

--- a/src/game/server/tf/tf_obj_dispenser.cpp
+++ b/src/game/server/tf/tf_obj_dispenser.cpp
@@ -207,13 +207,14 @@ void CObjectDispenser::SetModel( const char *pModel )
 //-----------------------------------------------------------------------------
 void CObjectDispenser::OnGoActive( void )
 {
+	/*
 	CTFPlayer *pBuilder = GetBuilder();
 
 	Assert( pBuilder );
 
 	if ( !pBuilder )
 		return;
-
+	*/
 	SetModel( DISPENSER_MODEL_LEVEL_1 );
 
 	// Put some ammo in the Dispenser

--- a/src/game/server/tf/tf_obj_sentrygun.cpp
+++ b/src/game/server/tf/tf_obj_sentrygun.cpp
@@ -239,13 +239,14 @@ bool CObjectSentrygun::StartBuilding( CBaseEntity *pBuilder )
 //-----------------------------------------------------------------------------
 void CObjectSentrygun::OnGoActive( void )
 {
+	/*
 	CTFPlayer *pBuilder = GetBuilder();
 
 	Assert( pBuilder );
 
 	if ( !pBuilder )
 		return;
-
+	*/
 	SetModel( SENTRY_MODEL_LEVEL_1 );
 
 	m_iState.Set( SENTRY_STATE_SEARCHING );
@@ -636,15 +637,28 @@ bool CObjectSentrygun::FindTarget()
 
 	// Find the opposing team list.
 	CTFPlayer *pPlayer = ToTFPlayer( GetOwner() );
-	if ( !pPlayer )
-		return false;
-
 	CUtlVector<CTFTeam *> pTeamList;
-	pPlayer->GetOpposingTFTeamList( &pTeamList );
+	CTFTeam *pTeam = NULL;
 
 	//CTFTeam *pTeam = pPlayer->GetOpposingTFTeam();
 	//if ( !pTeam )
 	//	return false;
+
+	if ( pPlayer )
+	{
+		// Try builder's team.
+		pTeam = pPlayer->GetTFTeam();
+	}
+	else
+	{
+		// If we have no builder use our own team number instead.
+		pTeam = GetTFTeam();
+	}
+
+	if ( pTeam )
+		pTeam->GetOpposingTFTeamList( &pTeamList );
+	else
+		return false;
 
 	// If we have an enemy get his minimum distance to check against.
 	Vector vecSegment;

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -5210,44 +5210,6 @@ CTFTeam *CTFPlayer::GetOpposingTFTeam( void )
 	}
 }
 
-void CTFPlayer::GetOpposingTFTeamList(CUtlVector<CTFTeam *> *pTeamList)
-{
-	if (TFGameRules()->IsDeathmatch())
-	{
-		pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_RED));
-		return;
-	}
-
-	int iTeam = GetTeamNumber();
-	switch (iTeam)
-	{
-		case TF_TEAM_RED:
-			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_BLUE));
-			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_GREEN));
-			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_YELLOW));
-			break;
-
-		case TF_TEAM_BLUE:
-			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_RED));
-			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_GREEN));
-			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_YELLOW));
-			break;
-
-		case TF_TEAM_GREEN:
-			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_RED));
-			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_BLUE));
-			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_YELLOW));
-			break;
-
-		case TF_TEAM_YELLOW:
-			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_RED));
-			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_BLUE));
-			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_GREEN));
-			break;
-	}
-
-}
-
 //-----------------------------------------------------------------------------
 // Purpose: Give this player the "i just teleported" effect for 12 seconds
 //-----------------------------------------------------------------------------

--- a/src/game/server/tf/tf_player.h
+++ b/src/game/server/tf/tf_player.h
@@ -256,7 +256,6 @@ public:
 
 	CTFTeam *GetTFTeam( void );
 	CTFTeam *GetOpposingTFTeam( void );
-	void GetOpposingTFTeamList( CUtlVector<CTFTeam *> *pTeamList );
 
 	void TeleportEffect( void );
 	void RemoveTeleportEffect( void );

--- a/src/game/server/tf/tf_team.cpp
+++ b/src/game/server/tf/tf_team.cpp
@@ -408,3 +408,48 @@ CTFTeam *GetGlobalTFTeam( int iIndex )
 
 	return ( dynamic_cast< CTFTeam* >( g_Teams[iIndex] ) );
 }
+
+void CTFPlayer::GetOpposingTFTeamList(CUtlVector<CTFTeam *> *pTeamList)
+{
+	if (TFGameRules()->IsDeathmatch())
+	{
+		pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_RED));
+		return;
+	}
+
+	int iTeam = GetTeamNumber();
+	switch (iTeam)
+	{
+		case TF_TEAM_RED:
+			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_BLUE));
+			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_GREEN));
+			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_YELLOW));
+			break;
+
+		case TF_TEAM_BLUE:
+			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_RED));
+			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_GREEN));
+			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_YELLOW));
+			break;
+
+		case TF_TEAM_GREEN:
+			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_RED));
+			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_BLUE));
+			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_YELLOW));
+			break;
+
+		case TF_TEAM_YELLOW:
+			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_RED));
+			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_BLUE));
+			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_GREEN));
+			break;
+			
+		default:
+			// Makes unassigned sentries shoot everyone, hehe.
+			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_RED));
+			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_BLUE));
+			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_GREEN));
+			pTeamList->AddToTail(TFTeamMgr()->GetTeam(TF_TEAM_YELLOW));
+			break;
+	}
+}

--- a/src/game/server/tf/tf_team.h
+++ b/src/game/server/tf/tf_team.h
@@ -51,6 +51,8 @@ public:
 	// Roles
 	void			SetRole( int iTeamRole ) { m_iRole = iTeamRole; }
 	int				GetRole( void ) { return m_iRole; }
+	
+	void 			GetOpposingTFTeamList( CUtlVector<CTFTeam *> *pTeamList );
 
 private:
 	

--- a/src/game/shared/tf/tf_weapon_flamethrower.cpp
+++ b/src/game/shared/tf/tf_weapon_flamethrower.cpp
@@ -882,7 +882,11 @@ void CTFFlameEntity::FlameThink( void )
 			return;
 
 		CUtlVector<CTFTeam *> pTeamList;
-		pAttacker->GetOpposingTFTeamList(&pTeamList);
+		CTFTeam *pTeam = pAttacker->GetTFTeam();
+		if ( pTeam )
+			pTeam->GetOpposingTFTeamList(&pTeamList);
+		else
+			return;
 
 		//CTFTeam *pTeam = pAttacker->GetOpposingTFTeam();
 		//if ( !pTeam )


### PR DESCRIPTION
Makes maps with pre-placed buildings work (e.g. tr_walkway).
Also, unassigned sentries shoot everyone now. :3
Teleporters do become solid (not blueprints) but don't go active since matching sides without a builder is too much work.