### PR TITLE
Some minor improvements

### DIFF
--- a/src/game/client/tf/tf_hud_deathnotice.cpp
+++ b/src/game/client/tf/tf_hud_deathnotice.cpp
@@ -414,7 +414,17 @@ void CTFHudDeathNotice::Paint()
 		if (assister[0])
 		{
 			// Draw a + between the names
-			DrawText(x, yText, m_hTextFont, GetInfoTextColor(i, msg.bLocalPlayerInvolved), L"+");
+			// If both killer and assister are on the same team paint + with team color
+			Color plusColor;
+			if ( msg.Killer.iTeam == msg.Assister.iTeam )
+			{
+				plusColor = GetTeamColor(msg.Killer.iTeam, msg.bLocalPlayerInvolved);
+			}
+			else
+			{
+				plusColor = GetInfoTextColor(i, msg.bLocalPlayerInvolved);
+			}
+			DrawText(x, yText, m_hTextFont, plusColor, L"+");
 			x += iPlusIconWide;
 
 			// Draw assister's name

--- a/src/game/client/tf/tf_hud_deathnotice.cpp
+++ b/src/game/client/tf/tf_hud_deathnotice.cpp
@@ -349,7 +349,7 @@ void CTFHudDeathNotice::Paint()
 
 		int iAssisterTextWide = assister[0] ? UTIL_ComputeStringWidth(m_hTextFont, assister) + xSpacing : 0;
 
-		int iPlusIconWide = assister[0] ? UTIL_ComputeStringWidth(m_hTextFont, " + ") + xSpacing : 0;
+		int iPlusIconWide = assister[0] ? UTIL_ComputeStringWidth(m_hTextFont, "+") + xSpacing : 0;
 
 		// Get the local position for this notice
 		if (icon)
@@ -382,7 +382,7 @@ void CTFHudDeathNotice::Paint()
 			iconPrekillerWide *= flScale;
 		}
 
-		int iTotalWide = iKillerTextWide + iAssisterTextWide + iPlusIconWide + iconWide + iVictimTextWide + iDeathInfoTextWide + iDeathInfoEndTextWide + (xMargin * 2);
+		int iTotalWide = iKillerTextWide + iPlusIconWide + iAssisterTextWide + iconWide + iVictimTextWide + iDeathInfoTextWide + iDeathInfoEndTextWide + (xMargin * 2);
 		iTotalWide += iconPrekillerWide + iPreKillerTextWide;
 
 		int y = yStart + ((iLineTall + m_flLineSpacing) * i);
@@ -414,7 +414,7 @@ void CTFHudDeathNotice::Paint()
 		if (assister[0])
 		{
 			// Draw a + between the names
-			DrawText(x, yText, m_hTextFont, GetInfoTextColor(i, msg.bLocalPlayerInvolved), L" + ");
+			DrawText(x, yText, m_hTextFont, GetInfoTextColor(i, msg.bLocalPlayerInvolved), L"+");
 			x += iPlusIconWide;
 
 			// Draw assister's name

--- a/src/game/client/tf/tf_hud_deathnotice.cpp
+++ b/src/game/client/tf/tf_hud_deathnotice.cpp
@@ -414,17 +414,7 @@ void CTFHudDeathNotice::Paint()
 		if (assister[0])
 		{
 			// Draw a + between the names
-			// If both killer and assister are on the same team paint + with team color
-			Color plusColor;
-			if ( msg.Killer.iTeam == msg.Assister.iTeam )
-			{
-				plusColor = GetTeamColor(msg.Killer.iTeam, msg.bLocalPlayerInvolved);
-			}
-			else
-			{
-				plusColor = GetInfoTextColor(i, msg.bLocalPlayerInvolved);
-			}
-			DrawText(x, yText, m_hTextFont, plusColor, L"+");
+			DrawText(x, yText, m_hTextFont, GetInfoTextColor(i, msg.bLocalPlayerInvolved), L"+");
 			x += iPlusIconWide;
 
 			// Draw assister's name

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -2140,10 +2140,29 @@ const char *CTFGameRules::GetKillingWeaponName( const CTakeDamageInfo &info, CTF
 		}
 	}
 
-	// look out for sentry rocket as weapon and map it to sentry gun, so we get the sentry death icon
+	// In case of a sentry kill change the icon according to sentry level.
+	if ( 0 == Q_strcmp( killer_weapon_name, "obj_sentrygun" ) )
+	{
+		CBaseObject* pObject = assert_cast<CBaseObject * >( pInflictor );
+
+		if ( pObject )
+		{
+			switch ( pObject->GetUpgradeLevel() )
+			{
+				case 2:
+					killer_weapon_name = "obj_sentrygun2";
+					break;
+				case 3:
+					killer_weapon_name = "obj_sentrygun3";
+					break;
+			}
+		}
+	}
+
+	// look out for sentry rocket as weapon and map it to sentry gun, so we get the L3 sentry death icon
 	if ( 0 == Q_strcmp( killer_weapon_name, "tf_projectile_sentryrocket" ) )
 	{
-		killer_weapon_name = "obj_sentrygun";
+		killer_weapon_name = "obj_sentrygun3";
 	}
 
 	return killer_weapon_name;


### PR DESCRIPTION
 * Fixed spacings in death notice again. There's too much space between + and player names.
 * Implemented L2 and L3 sentry kill icons. Icons are already listed in mod_textures, just needed coding.
 * "+" in death notice is painted with team color if both killer and assister are on the same team. Looks prettier that way. (: