### PR TITLE
Multiple additions

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -2556,8 +2556,19 @@ bool C_TFPlayer::CreateMove( float flInputSampleTime, CUserCmd *pCmd )
 		pCmd->forwardmove = 0.0f;
 		pCmd->sidemove = 0.0f;
 		pCmd->upmove = 0.0f;
+		int nOldButtons = pCmd->buttons;
 		pCmd->buttons = 0;
 		pCmd->weaponselect = 0;
+
+		// Re-add IN_ATTACK2 if player is Demoman with sticky launcher. This is done so they can detonate stickies while taunting.
+		if ( (nOldButtons & IN_ATTACK2) && IsPlayerClass( TF_CLASS_DEMOMAN ) )
+		{
+			CTFPipebombLauncher *pWeapon = dynamic_cast < CTFPipebombLauncher*>( Weapon_OwnsThisID( TF_WEAPON_PIPEBOMBLAUNCHER ) );
+			if ( pWeapon )
+			{
+				pCmd->buttons |= IN_ATTACK2;
+			}
+		}
 
 		VectorCopy( angMoveAngle, pCmd->viewangles );
 		bNoTaunt = false;

--- a/src/game/client/tf/tf_hud_damageaccount_panel.cpp
+++ b/src/game/client/tf/tf_hud_damageaccount_panel.cpp
@@ -105,6 +105,12 @@ void CTFDamageAccountPanel::FireGameEvent(IGameEvent * event)
 		if ( m_pDamageAccountLabel
 			&& C_TFPlayer::GetLocalTFPlayer()->GetUserID() == event->GetInt( "userid_from" ) ) // Did we shoot the guy?
 		{
+			if ( event->GetInt( "userid_from" ) == event->GetInt( "userid_to" ) )
+			{
+				// No self-damage notifications.
+				return;
+			}
+
 			// Play hit sound, if appliable
 			if( tf_dingalingaling.GetBool() == true )
 			{

--- a/src/game/server/tf/entity_ammopack.cpp
+++ b/src/game/server/tf/entity_ammopack.cpp
@@ -17,8 +17,6 @@
 // CTF AmmoPack defines.
 //
 
-#define TF_AMMOPACK_PICKUP_SOUND	"AmmoPack.Touch"
-
 LINK_ENTITY_TO_CLASS( item_ammopack_full, CAmmoPack );
 LINK_ENTITY_TO_CLASS( item_ammopack_small, CAmmoPackSmall );
 LINK_ENTITY_TO_CLASS( item_ammopack_medium, CAmmoPackMedium );

--- a/src/game/server/tf/entity_ammopack.h
+++ b/src/game/server/tf/entity_ammopack.h
@@ -12,6 +12,8 @@
 
 #include "tf_powerup.h"
 
+#define TF_AMMOPACK_PICKUP_SOUND	"AmmoPack.Touch"
+
 //=============================================================================
 //
 // CTF AmmoPack class.

--- a/src/game/server/tf/tf_ammo_pack.cpp
+++ b/src/game/server/tf/tf_ammo_pack.cpp
@@ -10,6 +10,8 @@
 #include "ammodef.h"
 #include "tf_gamerules.h"
 #include "explode.h"
+#include "tf_powerup.h"
+#include "entity_ammopack.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -60,6 +62,7 @@ void CTFAmmoPack::Spawn( void )
 
 void CTFAmmoPack::Precache( void )
 {
+	PrecacheScriptSound( TF_AMMOPACK_PICKUP_SOUND );
 }
 
 CTFAmmoPack *CTFAmmoPack::Create( const Vector &vecOrigin, const QAngle &vecAngles, CBaseEntity *pOwner, const char *pszModelName )
@@ -116,6 +119,10 @@ void CTFAmmoPack::PackTouch( CBaseEntity *pOther )
 
 	Assert( pPlayer );
 
+	// tf_ammo_pack (dropped weapons) originally packed killed player's ammo.
+	// This was changed to make them act as medium ammo packs.
+#if 0
+	// Old ammo giving code.
 	int iAmmoTaken = 0;
 
 	int i;
@@ -128,6 +135,47 @@ void CTFAmmoPack::PackTouch( CBaseEntity *pOther )
 	{
 		UTIL_Remove( this );
 	}
+#else
+	// Copy-paste from CAmmoPack code.
+
+	bool bSuccess = false;
+
+	CTFPlayer *pTFPlayer = ToTFPlayer( pPlayer );
+	if ( !pTFPlayer )
+		return;
+
+	int iMaxPrimary = pTFPlayer->GetPlayerClass()->GetData()->m_aAmmoMax[TF_AMMO_PRIMARY];
+	if ( pPlayer->GiveAmmo( ceil(iMaxPrimary * PackRatios[POWERUP_MEDIUM]), TF_AMMO_PRIMARY, true ) )
+	{
+		bSuccess = true;
+	}
+
+	int iMaxSecondary = pTFPlayer->GetPlayerClass()->GetData()->m_aAmmoMax[TF_AMMO_SECONDARY];
+	if ( pPlayer->GiveAmmo( ceil(iMaxSecondary * PackRatios[POWERUP_MEDIUM]), TF_AMMO_SECONDARY, true ) )
+	{
+		bSuccess = true;
+	}
+
+	int iMaxMetal = pTFPlayer->GetPlayerClass()->GetData()->m_aAmmoMax[TF_AMMO_METAL];
+	if ( pPlayer->GiveAmmo( ceil(iMaxMetal * PackRatios[POWERUP_MEDIUM]), TF_AMMO_METAL, true ) )
+	{
+		bSuccess = true;
+	}
+
+	if (pTFPlayer->m_Shared.GetSpyCloakMeter() < 100.0f)
+	{
+		pTFPlayer->m_Shared.SetSpyCloakMeter(min(100.0f, pTFPlayer->m_Shared.GetSpyCloakMeter() + ceil(100.0f * PackRatios[POWERUP_MEDIUM])));
+		bSuccess = true;
+	}
+
+	// did we give them anything?
+	if ( bSuccess )
+	{
+		CSingleUserRecipientFilter filter( pPlayer );
+		EmitSound( filter, entindex(), TF_AMMOPACK_PICKUP_SOUND );
+		UTIL_Remove( this );
+	}
+#endif
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/server/tf/tf_ammo_pack.cpp
+++ b/src/game/server/tf/tf_ammo_pack.cpp
@@ -162,9 +162,10 @@ void CTFAmmoPack::PackTouch( CBaseEntity *pOther )
 		bSuccess = true;
 	}
 
+	// Unlike medium ammo packs, restore only 25% cloak.
 	if (pTFPlayer->m_Shared.GetSpyCloakMeter() < 100.0f)
 	{
-		pTFPlayer->m_Shared.SetSpyCloakMeter(min(100.0f, pTFPlayer->m_Shared.GetSpyCloakMeter() + ceil(100.0f * PackRatios[POWERUP_MEDIUM])));
+		pTFPlayer->m_Shared.SetSpyCloakMeter(min(100.0f, pTFPlayer->m_Shared.GetSpyCloakMeter() + ceil(100.0f * 0.25f)));
 		bSuccess = true;
 	}
 

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -87,6 +87,7 @@ ConVar tf_birthday( "tf_birthday", "0", FCVAR_NOTIFY | FCVAR_REPLICATED );
 #ifdef GAME_DLL
 // TF overrides the default value of this convar
 ConVar mp_waitingforplayers_time( "mp_waitingforplayers_time", (IsX360()?"15":"30"), FCVAR_GAMEDLL | FCVAR_DEVELOPMENTONLY, "WaitingForPlayers time length in seconds" );
+ConVar tf2c_falldamage_disablespread( "tf2c_falldamage_disablespread", "0", FCVAR_NOTIFY, "Toggles random 20% fall damage spread." );
 #endif
 
 #ifdef GAME_DLL
@@ -2336,7 +2337,10 @@ float CTFGameRules::FlPlayerFallDamage( CBasePlayer *pPlayer )
 		float flRatio = (float)pPlayer->GetMaxHealth() / 100.0;
 		flFallDamage *= flRatio;
 
-		flFallDamage *= random->RandomFloat( 0.8, 1.2 );
+		if ( tf2c_falldamage_disablespread.GetBool() == false )
+		{
+			flFallDamage *= random->RandomFloat( 0.8, 1.2 );
+		}
 
 		return flFallDamage;
 	}


### PR DESCRIPTION
1. This is something I wanted to see for a while. Original TF2 has random 20% fall damage spread that is independent from regular damage spread. This cvar allows you to disable it (defaults to 0).
2. Dropped weapons mostly act as medium ammo packs now, restoring 50% of your ammo and 25% cloak (matches live TF2).
3. KABYYYYYM! This might not the best way but it's definitely the easiest one. Easier than adding a bunch of server side checks.
4. Fixed damage numbers and hitsound getting triggered by self-damage.