### PR TITLE
Client side nail trajectory fix + Grenade damage tweak

### DIFF
--- a/src/game/client/c_basecombatweapon.cpp
+++ b/src/game/client/c_basecombatweapon.cpp
@@ -506,7 +506,10 @@ int C_BaseCombatWeapon::CalcOverrideModelIndex()
 		localplayer == GetOwner() &&
 		ShouldDrawLocalPlayerViewModel() )
 	{
-		return BaseClass::CalcOverrideModelIndex();
+		//return BaseClass::CalcOverrideModelIndex();
+		// Temp fix for weapon model not getting set back to viewmodel after
+		// switching back from third person. (Nicknine, danielmm8888)
+		return m_iViewModelIndex;
 	}
 	else
 	{

--- a/src/game/shared/tf/tf_projectile_base.cpp
+++ b/src/game/shared/tf/tf_projectile_base.cpp
@@ -283,47 +283,11 @@ C_LocalTempEntity *ClientsideProjectileCallback( const CEffectData &data, float 
 		return NULL;
 	}
 
-	Vector vecSrc = data.m_vOrigin;
-
-	// If we're seeing another player shooting the nails, move their start point to the weapon origin
-	if ( pEnt && pEnt->IsPlayer() )
-	{
-		C_BasePlayer *pLocalPlayer = C_BasePlayer::GetLocalPlayer();
-		if ( pLocalPlayer != pEnt || ::input->CAM_IsThirdPerson() )
-		{
-			CTFPlayer *pTFPlayer = ToTFPlayer( pEnt );
-			if ( pTFPlayer->GetActiveWeapon() )
-			{
-				pTFPlayer->GetActiveWeapon()->GetAttachment( "muzzle", vecSrc );
-			}
-		}
-		else
-		{
-			C_BaseEntity *pViewModel = pLocalPlayer->GetViewModel();
-
-			if ( pViewModel )
-			{
-				QAngle vecAngles;
-				int iMuzzleFlashAttachment = pViewModel->LookupAttachment( "muzzle" );
-				pViewModel->GetAttachment( iMuzzleFlashAttachment, vecSrc, vecAngles );
-
-				Vector vForward;
-				AngleVectors( vecAngles, &vForward );
-
-				trace_t trace;	
-				UTIL_TraceLine( vecSrc + vForward * -50, vecSrc, MASK_SOLID, pEnt, COLLISION_GROUP_NONE, &trace );
-
-				vecSrc = trace.endpos;
-			}
-		}
-	}
-
-
 	float flGravity = ( flGravityBase * 800 );
 
 	Vector vecGravity(0,0,-flGravity);
 
-	return tempents->ClientProjectile( vecSrc, data.m_vStart, vecGravity, data.m_nMaterial, data.m_fFlags, pEnt, "Impact", pszParticleName );
+	return tempents->ClientProjectile( data.m_vOrigin, data.m_vStart, vecGravity, data.m_nMaterial, data.m_fFlags, pEnt, "Impact", pszParticleName );
 }
 
 //=============================================================================

--- a/src/game/shared/tf/tf_viewmodel.h
+++ b/src/game/shared/tf/tf_viewmodel.h
@@ -38,9 +38,8 @@ public:
 #if defined( CLIENT_DLL )
 	virtual bool ShouldPredict( void )
 	{
-		// Prediction often causes viewmodels to get bugged so I'm disabling this for now. (Nickine)
 		if ( GetOwner() && GetOwner() == C_BasePlayer::GetLocalPlayer() )
-			return false;
+			return true;
 
 		return BaseClass::ShouldPredict();
 	}

--- a/src/game/shared/tf/tf_weapon_grenade_pipebomb.cpp
+++ b/src/game/shared/tf/tf_weapon_grenade_pipebomb.cpp
@@ -519,6 +519,8 @@ void CTFGrenadePipebombProjectile::PipebombTouch( CBaseEntity *pOther )
 
 		// Restore damage. See comment in CTFGrenadePipebombProjectile::Create() above to understand this.
 		m_flDamage = m_flFullDamage;
+		// Save this entity as enemy, they will take 100% damage.
+		m_hEnemy = pOther;
 		Detonate();
 	}
 
@@ -547,6 +549,8 @@ void CTFGrenadePipebombProjectile::VPhysicsCollision( int index, gamevcollisione
 		// Blow up if we hit an enemy we can damage
 		if ( pHitEntity->GetTeamNumber() && pHitEntity->GetTeamNumber() != GetTeamNumber() && pHitEntity->m_takedamage != DAMAGE_NO )
 		{
+			// Save this entity as enemy, they will take 100% damage.
+			m_hEnemy = pHitEntity;
 			SetThink( &CTFGrenadePipebombProjectile::Detonate );
 			SetNextThink( gpGlobals->curtime );
 		}

--- a/src/game/shared/tf/tf_weapon_grenade_pipebomb.h
+++ b/src/game/shared/tf/tf_weapon_grenade_pipebomb.h
@@ -82,6 +82,7 @@ public:
 
 	virtual int		OnTakeDamage( const CTakeDamageInfo &info );
 
+	virtual CBaseEntity		*GetEnemy( void )			{ return m_hEnemy; }
 
 private:
 
@@ -89,6 +90,8 @@ private:
 	bool		m_bFizzle;
 
 	float		m_flMinSleepTime;
+
+	CHandle<CBaseEntity>	m_hEnemy;
 #endif
 };
 #endif // TF_WEAPON_GRENADE_PIPEBOMB_H


### PR DESCRIPTION
* Doesn't affect rocket firing since that is entirely server side.
* Grenades always do full damage on direct hit regardless of where they hit.
* Improved hunter rifle code, removed redundant reload calls, fixed a glitch with reloading.