### PR TITLE
+use to enable auto-pickup for weapon spawners

### DIFF
--- a/src/game/server/tf/entity_weaponspawn.cpp
+++ b/src/game/server/tf/entity_weaponspawn.cpp
@@ -99,8 +99,10 @@ bool CWeaponSpawner::MyTouch(CBasePlayer *pPlayer)
 				if ( pPlayer->GiveAmmo(999, pWeaponInfo->iAmmoType) )
 					bSuccess = true;
 			}
-			else if ( !(pTFPlayer->m_nButtons & IN_ATTACK) )
+			else if ( !(pTFPlayer->m_nButtons & IN_ATTACK) && 
+			(pTFPlayer->m_nButtons & IN_USE || pWeapon->GetWeaponID() == TF_WEAPON_PISTOL) )
 			{
+				// Check Use button, always replace pistol
 				pTFPlayer->Weapon_Detach(pWeapon);
 				UTIL_Remove(pWeapon);
 				pWeapon = NULL;

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -1744,6 +1744,53 @@ void CTFPlayer::HandleCommand_JoinTeam_NoMenus( const char *pTeamName )
 }
 
 //-----------------------------------------------------------------------------
+// Purpose: Join a team without suiciding
+//-----------------------------------------------------------------------------
+void CTFPlayer::HandleCommand_JoinTeam_NoKill( const char *pTeamName )
+{
+	if ( TFGameRules()->IsDeathmatch() && stricmp( pTeamName, "spectate" ) != 0 )
+	{
+		ChangeTeam(TF_TEAM_RED);
+		SetDesiredPlayerClassIndex(TF_CLASS_MERCENARY);
+		return;
+	}
+
+	int iTeam = TF_TEAM_RED;
+	if ( stricmp( pTeamName, "auto" ) == 0 )
+	{
+		iTeam = GetAutoTeam();
+	}
+	else if ( stricmp( pTeamName, "spectate" ) == 0 )
+	{
+		iTeam = TEAM_SPECTATOR;
+	}
+	else
+	{
+		for ( int i = 0; i < TF_TEAM_COUNT; ++i )
+		{
+			if ( stricmp( pTeamName, g_aTeamNames[i] ) == 0 )
+			{
+				iTeam = i;
+				break;
+			}
+		}
+	}
+
+	if (iTeam > TF_TEAM_BLUE && !TFGameRules()->IsFourTeamGame())
+	{
+		Warning("Four player teams have been disabled!\n");
+		return;
+	}
+
+	if (iTeam == GetTeamNumber())
+	{
+		return;	// we wouldn't change the team
+	}
+
+	BaseClass::ChangeTeam( iTeam );
+}
+
+//-----------------------------------------------------------------------------
 // Purpose: Player has been forcefully changed to another team
 //-----------------------------------------------------------------------------
 void CTFPlayer::ForceChangeTeam( int iTeamNum )
@@ -2127,6 +2174,18 @@ bool CTFPlayer::ClientCommand( const CCommand &args )
 			if ( args.ArgC() >= 2 )
 			{
 				HandleCommand_JoinTeam_NoMenus( args[1] );
+			}
+			return true;
+		}
+		return false;
+	}
+	else if ( FStrEq( pcmd, "jointeam_nokill" ) )
+	{
+		if ( sv_cheats->GetBool() )
+		{
+			if ( args.ArgC() >= 2 )
+			{
+				HandleCommand_JoinTeam_NoKill( args[1] );
 			}
 			return true;
 		}

--- a/src/game/server/tf/tf_player.h
+++ b/src/game/server/tf/tf_player.h
@@ -422,6 +422,7 @@ private:
 	void				HandleCommand_JoinTeam( const char *pTeamName );
 	void				HandleCommand_JoinClass( const char *pClassName );
 	void				HandleCommand_JoinTeam_NoMenus( const char *pTeamName );
+	void				HandleCommand_JoinTeam_NoKill( const char *pTeamName );
 
 	// Bots.
 	friend void			Bot_Think( CTFPlayer *pBot );


### PR DESCRIPTION
* Pistol always gets auto-replaced. To replace a weapon touch weapon spawner while pressing Use button.
* jointeam_nokill - cheat restricted command, changes player's team without killing him.