### PR TITLE
Disguise weapon switching + Bugfixes

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -3677,39 +3677,6 @@ void C_TFPlayer::SetHealer( C_TFPlayer *pHealer, float flChargeLevel )
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-float C_TFPlayer::MedicGetChargeLevel( void )
-{
-	if ( IsPlayerClass(TF_CLASS_MEDIC) )
-	{
-		CTFWeaponBase *pWpn = ( CTFWeaponBase *)Weapon_OwnsThisID( TF_WEAPON_MEDIGUN );
-
-		if ( pWpn == NULL )
-			return 0;
-
-		CWeaponMedigun *pWeapon = dynamic_cast <CWeaponMedigun*>( pWpn );
-
-		if ( pWeapon )
-			return pWeapon->GetChargeLevel();
-	}
-
-	if (IsPlayerClass(TF_CLASS_MEDIC))
-	{
-		CTFWeaponBase *pWpn = (CTFWeaponBase *)Weapon_OwnsThisID(TF_WEAPON_KRITZKRIEG);
-
-		if (pWpn == NULL)
-			return 0;
-
-		CWeaponKritzkrieg *pWeapon = dynamic_cast <CWeaponKritzkrieg*>(pWpn);
-
-		if (pWeapon)
-			return pWeapon->GetChargeLevel();
-	}
-	return 0;
-}
-
-//-----------------------------------------------------------------------------
-// Purpose: 
-//-----------------------------------------------------------------------------
 CBaseEntity *C_TFPlayer::MedicGetHealTarget( void )
 {
 	if ( IsPlayerClass(TF_CLASS_MEDIC) )

--- a/src/game/client/tf/tf_hud_target_id.cpp
+++ b/src/game/client/tf/tf_hud_target_id.cpp
@@ -373,7 +373,7 @@ void CTargetID::UpdateID( void )
 				}
 			}
 
-			if ( pPlayer->IsPlayerClass( TF_CLASS_MEDIC ) )
+			if ( pPlayer->IsPlayerClass( TF_CLASS_MEDIC ) || (bDisguisedEnemy && pPlayer->m_Shared.GetDisguiseClass() == TF_CLASS_MEDIC) )
 			{
 				wchar_t wszChargeLevel[ 10 ];
 				_snwprintf( wszChargeLevel, ARRAYSIZE(wszChargeLevel) - 1, L"%.0f", pPlayer->MedicGetChargeLevel() * 100 );
@@ -399,16 +399,17 @@ void CTargetID::UpdateID( void )
 
 				if ( tf_PR )
 				{
-					flMaxHealth = tf_PR->GetMaxHealth( m_iTargetEntIndex );
-					iMaxBuffedHealth = pPlayer->m_Shared.GetMaxBuffedHealth();
-
 					if ( bDisguisedEnemy )
 					{
 						flHealth = (float)pPlayer->m_Shared.GetDisguiseHealth();
+						flMaxHealth = pPlayer->m_Shared.GetDisguiseMaxHealth();
+						iMaxBuffedHealth = pPlayer->m_Shared.GetDisguiseMaxBuffedHealth();
 					}
 					else
 					{
 						flHealth = (float)pPlayer->GetHealth();
+						flMaxHealth = tf_PR->GetMaxHealth( m_iTargetEntIndex );
+						iMaxBuffedHealth = pPlayer->m_Shared.GetMaxBuffedHealth();
 					}
 				}
 				else

--- a/src/game/client/tf/tf_hud_target_id.cpp
+++ b/src/game/client/tf/tf_hud_target_id.cpp
@@ -307,6 +307,7 @@ void CTargetID::UpdateID( void )
 		float flHealth = 0;
 		float flMaxHealth = 1;
 		int iMaxBuffedHealth = 0;
+		m_pAvatar->SetPlayer( NULL );
 
 		// Some entities we always want to check, cause the text may change
 		// even while we're looking at it
@@ -451,6 +452,12 @@ void CTargetID::UpdateID( void )
 				flHealth = pObj->GetHealth();
 				flMaxHealth = pObj->GetMaxHealth();
 				SetColorForTargetTeam( pObj->GetTeamNumber() );
+				C_TFPlayer *pBuilder = pObj->GetBuilder();
+				if ( pBuilder )
+				{
+					m_pAvatar->SetPlayer( (C_BasePlayer *)pBuilder );
+					m_pAvatar->SetShouldDrawFriendIcon(false);
+				}
 			}
 		}
 

--- a/src/game/server/tf/entity_weaponspawn.cpp
+++ b/src/game/server/tf/entity_weaponspawn.cpp
@@ -104,6 +104,7 @@ bool CWeaponSpawner::MyTouch(CBasePlayer *pPlayer)
 			{
 				// Check Use button, always replace pistol
 				pTFPlayer->Weapon_Detach(pWeapon);
+				pWeapon->WeaponReset();
 				UTIL_Remove(pWeapon);
 				pWeapon = NULL;
 			}

--- a/src/game/server/tf/tf_player.h
+++ b/src/game/server/tf/tf_player.h
@@ -394,6 +394,8 @@ public:
 
 	virtual bool			WantsLagCompensationOnEntity( const CBasePlayer	*pPlayer, const CUserCmd *pCmd, const CBitVec<MAX_EDICTS> *pEntityTransmitBits ) const;
 
+	float				MedicGetChargeLevel( void );
+
 	CTFWeaponBase		*Weapon_OwnsThisID( int iWeaponID );
 	CTFWeaponBase		*Weapon_GetWeaponByType( int iType );
 	CTFWeaponBase		*Weapon_GetWeaponByBucket (int iSlot );

--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -1655,7 +1655,7 @@ void CTFPlayerShared::RecalcDisguiseWeapon( int iSlot /*= 0*/ )
 	C_TFPlayer *pDisguiseTarget = ToTFPlayer( GetDisguiseTarget() );
 
 	// Use disguise target's weapons if possible.
-	if ( pDisguiseTarget && pDisguiseTarget->IsPlayerClass( m_nDisguiseClass ) )
+	if ( pDisguiseTarget && pDisguiseTarget->IsPlayerClass( m_nDisguiseClass ) && pDisguiseTarget->IsAlive() )
 	{
 		if ( pDisguiseTarget->Weapon_GetWeaponByBucket( iSlot ) )
 		{

--- a/src/game/shared/tf/tf_player_shared.h
+++ b/src/game/shared/tf/tf_player_shared.h
@@ -146,7 +146,7 @@ public:
 
 #ifdef CLIENT_DLL
 	void	OnDisguiseChanged( void );
-	void	RecalcDisguiseWeapon( void );
+	void	RecalcDisguiseWeapon( int iSlot = 0 );
 	int		GetDisguiseWeaponModelIndex( void ) { return m_iDisguiseWeaponModelIndex; }
 	CTFWeaponInfo *GetDisguiseWeaponInfo( void );
 #endif
@@ -255,6 +255,7 @@ private:
 	CNetworkVar( int, m_iDisguiseHealth );		// Health to show our enemies in player id
 	CNetworkVar( int, m_nDesiredDisguiseClass );
 	CNetworkVar( int, m_nDesiredDisguiseTeam );
+	CNetworkVar( bool, m_bDisguiseWeaponParity );
 
 	bool m_bEnableSeparation;		// Keeps separation forces on when player stops moving, but still penetrating
 	Vector m_vSeparationVelocity;	// Velocity used to keep player seperate from teammates
@@ -324,6 +325,8 @@ private:
 	CTFWeaponInfo *m_pDisguiseWeaponInfo;
 
 	WEAPON_FILE_INFO_HANDLE	m_hDisguiseWeaponInfo;
+
+	bool m_bOldDisguiseWeaponParity;
 #endif
 };			   
 

--- a/src/game/shared/tf/tf_player_shared.h
+++ b/src/game/shared/tf/tf_player_shared.h
@@ -143,6 +143,8 @@ public:
 	}
 	int		GetDisguiseHealth( void )			{ return m_iDisguiseHealth; }
 	void	SetDisguiseHealth( int iDisguiseHealth );
+	int		GetDisguiseMaxHealth( void )		{ return m_iDisguiseMaxHealth; }
+	int		GetDisguiseMaxBuffedHealth( void );
 
 #ifdef CLIENT_DLL
 	void	OnDisguiseChanged( void );
@@ -253,6 +255,8 @@ private:
 	EHANDLE m_hDisguiseTarget;					// Playing the spy is using for name disguise.
 	CNetworkVar( int, m_iDisguiseTargetIndex );
 	CNetworkVar( int, m_iDisguiseHealth );		// Health to show our enemies in player id
+	CNetworkVar( int, m_iDisguiseMaxHealth );
+	CNetworkVar( float, m_flDisguiseChargeLevel );
 	CNetworkVar( int, m_nDesiredDisguiseClass );
 	CNetworkVar( int, m_nDesiredDisguiseTeam );
 	CNetworkVar( bool, m_bDisguiseWeaponParity );

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -1998,8 +1998,7 @@ acttable_t *CTFWeaponBase::ActivityList( void )
 	}
 
 #ifdef CLIENT_DLL
-	// If we're disguised, we always show the primary weapon
-	// even though our actual weapon may not be primary 
+	// If we're disguised, we show a different weapon from what we're actually carrying.
 	CTFPlayer *pPlayer = GetTFPlayerOwner();
 	if ( pPlayer && pPlayer->m_Shared.InCond( TF_COND_DISGUISED ) && pPlayer->IsEnemyPlayer() )
 	{

--- a/src/game/shared/tf/tf_weaponbase.h
+++ b/src/game/shared/tf/tf_weaponbase.h
@@ -127,6 +127,7 @@ class CTFWeaponBase : public CBaseCombatWeapon
 	virtual void Drop( const Vector &vecVelocity );
 	virtual bool Holster( CBaseCombatWeapon *pSwitchingTo = NULL );
 	virtual bool Deploy( void );
+	virtual bool HolsterOnDetach() { return true; }
 
 	// Attacks.
 	virtual void PrimaryAttack();
@@ -141,6 +142,7 @@ class CTFWeaponBase : public CBaseCombatWeapon
 	virtual bool DefaultReload( int iClipSize1, int iClipSize2, int iActivity );
 	void SendReloadEvents();
 	virtual bool CanAutoReload( void ) { return true; }
+	virtual bool ReloadOrSwitchWeapons( void );
 
 	virtual bool CanDrop( void ) { return false; }
 
@@ -152,8 +154,6 @@ class CTFWeaponBase : public CBaseCombatWeapon
 	virtual void ItemPostFrame( void );
 
 	virtual void SetWeaponVisible( bool visible );
-
-	virtual bool ReloadOrSwitchWeapons( void );
 
 	virtual acttable_t *ActivityList( void );
 	virtual int ActivityListCount( void );


### PR DESCRIPTION
* Weapon_Detach() now calls Holster() for TF2 weapons. This fixes bugs like merc remaining slowed after swapping revved up minigun, etc.
* Target ID now shows avatar of building's owner.