### PR TITLE
Tweaks and bugfixes

### DIFF
--- a/src/game/server/tf/tf_ammo_pack.h
+++ b/src/game/server/tf/tf_ammo_pack.h
@@ -12,8 +12,6 @@
 
 #include "items.h"
 
-#define TF_DROPPED_WEAPON_METAL 100
-
 class CTFAmmoPack : public CItem
 {
 public:

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -4028,8 +4028,7 @@ void CTFPlayer::DropAmmoPack( void )
 	// Fill the ammo pack with unused player ammo, if out add a minimum amount.
 	int iPrimary = max( 5, GetAmmoCount( TF_AMMO_PRIMARY ) );
 	int iSecondary = max( 5, GetAmmoCount( TF_AMMO_SECONDARY ) );
-	int iMetal = TF_DROPPED_WEAPON_METAL;
-	//int iMetal = max( 5, GetAmmoCount( TF_AMMO_METAL ) );	
+	int iMetal = max( 5, GetAmmoCount( TF_AMMO_METAL ) );
 
 	// Create the ammo pack.
 	CTFAmmoPack *pAmmoPack = CTFAmmoPack::Create( vecPackOrigin, vecPackAngles, this, pszWorldModel );

--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -2103,7 +2103,7 @@ void CTFPlayerShared::UpdateCritMult( void )
 
 	if ( m_DamageEvents.Count() == 0 )
 	{
-		m_iCritMult = RemapValClamped( flMinMult, 1.0, 4.0, 0, 255 );
+		m_iCritMult = RemapValClamped( flMinMult, flMinMult, flMaxMult, 0, 255 );
 		return;
 	}
 
@@ -2142,7 +2142,7 @@ void CTFPlayerShared::UpdateCritMult( void )
 
 	//Msg( "   TotalDamage: %.2f   -> Mult %.2f\n", flTotalDamage, flMult );
 
-	m_iCritMult = (int)RemapValClamped( flMult, 1.0, TF_DAMAGE_CRITMOD_MAXMULT, 0, 255 );
+	m_iCritMult = (int)RemapValClamped( flMult, flMinMult, flMaxMult, 0, 255 );
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -2082,7 +2082,7 @@ void CTFPlayerShared::SetAirDash( bool bAirDash )
 //-----------------------------------------------------------------------------
 float CTFPlayerShared::GetCritMult( void )
 {
-	float flRemapCritMul = RemapValClamped( m_iCritMult, 0, 255, 1.0, 4.0 );
+	float flRemapCritMul = RemapValClamped( m_iCritMult, 0, 255, 1.0, TF_DAMAGE_CRITMOD_MAXMULT );
 /*#ifdef CLIENT_DLL
 	Msg("CLIENT: Crit mult %.2f - %d\n",flRemapCritMul, m_iCritMult);
 #else
@@ -2142,7 +2142,7 @@ void CTFPlayerShared::UpdateCritMult( void )
 
 	//Msg( "   TotalDamage: %.2f   -> Mult %.2f\n", flTotalDamage, flMult );
 
-	m_iCritMult = (int)RemapValClamped( flMult, 1.0, 4.0, 0, 255 );
+	m_iCritMult = (int)RemapValClamped( flMult, 1.0, TF_DAMAGE_CRITMOD_MAXMULT, 0, 255 );
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -42,8 +42,7 @@ extern ConVar tf2c_model_muzzleflash;
 extern ConVar tf2c_muzzlelight;
 #endif
 
-ConVar tf_weapon_criticals("tf_weapon_criticals", "1", FCVAR_NOTIFY | FCVAR_REPLICATED,"Whether or not random crits are enabled\n" );
-extern ConVar tf_weapon_criticals_melee;
+ConVar tf_weapon_criticals( "tf_weapon_criticals", "1", FCVAR_NOTIFY | FCVAR_REPLICATED, "Whether or not random crits are enabled." );
 
 //=============================================================================
 //
@@ -521,18 +520,10 @@ void CTFWeaponBase::CalcIsAttackCritical( void)
 	{
 		m_bCurrentAttackIsCrit = true;
 	}
-	else if ( IsMeleeWeapon() && ((tf_weapon_criticals_melee.GetInt() == 1 && tf_weapon_criticals.GetBool()) || tf_weapon_criticals_melee.GetInt() == 2))
-	{
-		m_bCurrentAttackIsCrit = CalcIsAttackCriticalHelper();
-	}
-	else if ( tf_weapon_criticals.GetBool() )
+	else
 	{
 		// call the weapon-specific helper method
 		m_bCurrentAttackIsCrit = CalcIsAttackCriticalHelper();
-	}
-	else
-	{
-		m_bCurrentAttackIsCrit = false;
 	}
 }
 
@@ -543,6 +534,10 @@ bool CTFWeaponBase::CalcIsAttackCriticalHelper()
 {
 	CTFPlayer *pPlayer = ToTFPlayer( GetPlayerOwner() );
 	if ( !pPlayer )
+		return false;
+
+	// Don't bother checking if random crits are off.
+	if ( !tf_weapon_criticals.GetBool() )
 		return false;
 
 	float flPlayerCritMult = pPlayer->GetCritMult();

--- a/src/game/shared/tf/tf_weaponbase_melee.cpp
+++ b/src/game/shared/tf/tf_weaponbase_melee.cpp
@@ -47,7 +47,8 @@ END_DATADESC()
 ConVar tf_meleeattackforcescale( "tf_meleeattackforcescale", "80.0", FCVAR_CHEAT | FCVAR_GAMEDLL | FCVAR_DEVELOPMENTONLY );
 #endif
 
-ConVar tf_weapon_criticals_melee("tf_weapon_criticals_melee", "2", FCVAR_NOTIFY | FCVAR_REPLICATED,"Controls random crits for melee weapons.\n0 - Melee weapons do not randomly crit. \n1 - Melee weapons can randomly crit only if tf_weapon_criticals is also enabled. \n2 - Melee weapons can always randomly crit regardless of the tf_weapon_criticals setting.");
+ConVar tf_weapon_criticals_melee( "tf_weapon_criticals_melee", "2", FCVAR_NOTIFY | FCVAR_REPLICATED, "Controls random crits for melee weapons.\n0 - Melee weapons do not randomly crit. \n1 - Melee weapons can randomly crit only if tf_weapon_criticals is also enabled. \n2 - Melee weapons can always randomly crit regardless of the tf_weapon_criticals setting.", true, 0, true, 2 );
+extern ConVar tf_weapon_criticals;
 
 //=============================================================================
 //
@@ -169,8 +170,7 @@ void CTFWeaponBaseMelee::SecondaryAttack()
 //-----------------------------------------------------------------------------
 void CTFWeaponBaseMelee::Swing( CTFPlayer *pPlayer )
 {
-	if (tf_weapon_criticals_melee.GetInt() != 0)
-		CalcIsAttackCritical();
+	CalcIsAttackCritical();
 
 	// Play the melee swing and miss (whoosh) always.
 	SendPlayerAnimEvent( pPlayer );
@@ -386,6 +386,14 @@ bool CTFWeaponBaseMelee::CalcIsAttackCriticalHelper( void )
 {
 	CTFPlayer *pPlayer = ToTFPlayer( GetPlayerOwner() );
 	if ( !pPlayer )
+		return false;
+
+	int iShouldCrit = tf_weapon_criticals_melee.GetInt();
+
+	if ( iShouldCrit == 0 )
+		return false;
+
+	if ( iShouldCrit == 1 && !tf_weapon_criticals.GetBool() )
 		return false;
 
 	float flPlayerCritMult = pPlayer->GetCritMult();


### PR DESCRIPTION
* Improved tf_weapon_criticals cvar handling. Fixes backstabs not being crits if random crits are disabled.
* Fixed crit multiplier maxing out at x4 instead of x6 like it's supposed to.
* Fixed metal amount dropped by killed players. Engineers now drop the exact amount of metal they're carrying like in live TF2.