### PR TITLE
Ignore vcxproj filters and vpc_crc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ ipch
 *.opensdf
 *.idb
 *.vcxproj
+*.vcxproj.filters
+*.vcxproj.vpc_crc
 *.sln
 
 # OSX/Linux build products


### PR DESCRIPTION
Adds ignore rules for some files generated by Visual Studio and VPC.