### PR TITLE
Gibbing behavior + burn weapon detection

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -2110,7 +2110,7 @@ void C_TFPlayer::UpdateRecentlyTeleportedEffect( void )
 {
 	if ( m_Shared.ShouldShowRecentlyTeleported() )
 	{
-		if ( !m_pTeleporterEffect && !m_Shared.InCond( TF_COND_STEALTHED ) )
+		if ( !m_pTeleporterEffect )
 		{
 			char *pEffect = NULL;
 

--- a/src/game/client/tf/tf_hud_deathnotice.cpp
+++ b/src/game/client/tf/tf_hud_deathnotice.cpp
@@ -245,11 +245,6 @@ void CTFHudDeathNotice::OnGameEvent(IGameEvent *event, int iDeathNoticeMsg)
 		case TF_DMG_CUSTOM_HEADSHOT:
 			Q_strncpy(m_DeathNotices[iDeathNoticeMsg].szIcon, "d_headshot", ARRAYSIZE(m_DeathNotices[iDeathNoticeMsg].szIcon));
 			break;
-		case TF_DMG_CUSTOM_BURNING:
-			// special-case if custom kill is burning; if the attacker is dead we can't get weapon information, so force flamethrower as weapon
-			Q_strncpy(m_DeathNotices[iDeathNoticeMsg].szIcon, "d_flamethrower", ARRAYSIZE(m_DeathNotices[iDeathNoticeMsg].szIcon));
-			m_DeathNotices[iDeathNoticeMsg].wzInfoText[0] = 0;
-			break;
 		case TF_DMG_CUSTOM_SUICIDE:
 			{
 				// display a different message if this was suicide, or assisted suicide (suicide w/recent damage, kill awarded to damager)

--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -923,7 +923,7 @@ void CTFPlayerShared::ConditionGameRulesThink( void )
 		else if ( ( gpGlobals->curtime >= m_flFlameBurnTime ) && ( TF_CLASS_PYRO != m_pOuter->GetPlayerClass()->GetClassIndex() ) )
 		{
 			// Burn the player (if not pyro, who does not take persistent burning damage)
-			CTakeDamageInfo info( m_hBurnAttacker, m_hBurnAttacker, TF_BURNING_DMG, DMG_BURN | DMG_PREVENT_PHYSICS_FORCE, TF_DMG_CUSTOM_BURNING );
+			CTakeDamageInfo info( m_hBurnAttacker, m_hBurnAttacker, m_hBurnWeapon, TF_BURNING_DMG, DMG_BURN | DMG_PREVENT_PHYSICS_FORCE, TF_DMG_CUSTOM_BURNING );
 			m_pOuter->TakeDamage( info );
 			m_flFlameBurnTime = gpGlobals->curtime + TF_BURNING_FREQUENCY;
 		}
@@ -1323,7 +1323,7 @@ void CTFPlayerShared::OnRemoveRagemode(void)
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-void CTFPlayerShared::Burn( CTFPlayer *pAttacker )
+void CTFPlayerShared::Burn( CTFPlayer *pAttacker, CTFWeaponBase *pWeapon )
 {
 #ifdef CLIENT_DLL
 
@@ -1350,6 +1350,7 @@ void CTFPlayerShared::Burn( CTFPlayer *pAttacker )
 	float flFlameLife = bVictimIsPyro ? TF_BURNING_FLAME_LIFE_PYRO : TF_BURNING_FLAME_LIFE;
 	m_flFlameRemoveTime = gpGlobals->curtime + flFlameLife;
 	m_hBurnAttacker = pAttacker;
+	m_hBurnWeapon = pWeapon;
 
 #endif
 }
@@ -1377,6 +1378,7 @@ void CTFPlayerShared::OnRemoveBurning( void )
 	m_pOuter->m_flBurnEffectEndTime = 0;
 #else
 	m_hBurnAttacker = NULL;
+	m_hBurnWeapon = NULL;
 #endif
 }
 

--- a/src/game/shared/tf/tf_player_shared.h
+++ b/src/game/shared/tf/tf_player_shared.h
@@ -170,7 +170,7 @@ public:
 #endif
 	int		GetNumHealers( void ) { return m_nNumHealers; }
 
-	void	Burn( CTFPlayer *pPlayer );
+	void	Burn( CTFPlayer *pAttacker, CTFWeaponBase *pWeapon );
 
 	// Weapons.
 	CTFWeaponBase *GetActiveTFWeapon() const;
@@ -328,6 +328,7 @@ private:
 
 	// Burn handling
 	CHandle<CTFPlayer>		m_hBurnAttacker;
+	CHandle<CTFWeaponBase>	m_hBurnWeapon;
 	CNetworkVar( int,		m_nNumFlames );
 	float					m_flFlameBurnTime;
 	float					m_flFlameRemoveTime;

--- a/src/game/shared/tf/tf_player_shared.h
+++ b/src/game/shared/tf/tf_player_shared.h
@@ -156,6 +156,7 @@ public:
 	int		GetDisguiseWeaponModelIndex( void ) { return m_iDisguiseWeaponModelIndex; }
 	CTFWeaponInfo *GetDisguiseWeaponInfo( void );
 
+	void	UpdateCritBoostEffect( bool bForceHide );
 	bool	SetParticleToMercColor( CNewParticleEffect *pParticle );
 #endif
 
@@ -258,10 +259,6 @@ private:
 	void OnRemoveRagemode( void );
 
 	float GetCritMult( void );
-
-#ifdef CLIENT_DLL
-	void UpdateCritBoostEffect( bool bForceHide );
-#endif
 
 #ifdef GAME_DLL
 	void  UpdateCritMult( void );

--- a/src/game/shared/tf/tf_projectile_flare.cpp
+++ b/src/game/shared/tf/tf_projectile_flare.cpp
@@ -157,7 +157,7 @@ void CTFProjectile_Flare::Explode( trace_t *pTrace, CBaseEntity *pOther )
 	CTFPlayer *pPlayer = dynamic_cast <CTFPlayer*>(pOther);
 	if ( pPlayer )
 	{
-		CTakeDamageInfo info( this, pAttacker, 10, DMG_IGNITE, TF_DMG_CUSTOM_BURNING );
+		CTakeDamageInfo info( this, pAttacker, m_hLauncher, 10, DMG_IGNITE, TF_DMG_CUSTOM_BURNING );
 		info.SetReportedPosition( GetScorer()->GetAbsOrigin() );
 		pPlayer->TakeDamage( info );
 	}

--- a/src/game/shared/tf/tf_weapon_flamethrower.cpp
+++ b/src/game/shared/tf/tf_weapon_flamethrower.cpp
@@ -1174,7 +1174,7 @@ void CTFFlameEntity::OnCollide( CBaseEntity *pOther )
 	if ( !pAttacker )
 		return;
 
-	CTakeDamageInfo info( GetOwnerEntity(), pAttacker, flDamage, m_iDmgType, TF_DMG_CUSTOM_BURNING );
+	CTakeDamageInfo info( GetOwnerEntity(), pAttacker, GetOwnerEntity(), flDamage, m_iDmgType, TF_DMG_CUSTOM_BURNING );
 	info.SetReportedPosition( pAttacker->GetAbsOrigin() );
 
 	// We collided with pOther, so try to find a place on their surface to show blood

--- a/src/game/shared/tf/tf_weapon_grenade_pipebomb.cpp
+++ b/src/game/shared/tf/tf_weapon_grenade_pipebomb.cpp
@@ -62,7 +62,6 @@ RecvPropEHandle( RECVINFO( m_hLauncher ) ),
 SendPropBool( SENDINFO( m_bTouched ) ),
 SendPropInt( SENDINFO( m_iType ), 2 ),
 SendPropEHandle( SENDINFO( m_hLauncher ) ),
-
 #endif
 END_NETWORK_TABLE()
 

--- a/src/game/shared/tf/tf_weapon_grenade_pipebomb.h
+++ b/src/game/shared/tf/tf_weapon_grenade_pipebomb.h
@@ -45,7 +45,6 @@ public:
 	bool		m_bPulsed;
 	float		m_flFullDamage;
 
-	CNetworkHandle( CBaseEntity, m_hLauncher );
 	virtual void	UpdateOnRemove( void );
 
 
@@ -73,8 +72,6 @@ public:
 	virtual void	BounceSound( void );
 	virtual void	Detonate();
 	virtual void	Fizzle();
-
-	virtual void	SetLauncher( CBaseEntity *pLauncher ) { m_hLauncher = pLauncher; }
 
 	void			SetPipebombMode( bool bRemoteDetonate );
 

--- a/src/game/shared/tf/tf_weapon_pipebomblauncher.cpp
+++ b/src/game/shared/tf/tf_weapon_pipebomblauncher.cpp
@@ -276,7 +276,6 @@ CBaseEntity *CTFPipebombLauncher::FireProjectile( CTFPlayer *pPlayer )
 		}
 
 		CTFGrenadePipebombProjectile *pPipebomb = (CTFGrenadePipebombProjectile*)pProjectile;
-		pPipebomb->SetLauncher( this );
 
 		PipebombHandle hHandle;
 		hHandle = pPipebomb;

--- a/src/game/shared/tf/tf_weaponbase_grenadeproj.cpp
+++ b/src/game/shared/tf/tf_weaponbase_grenadeproj.cpp
@@ -318,7 +318,7 @@ void CTFWeaponBaseGrenadeProj::Explode( trace_t *pTrace, int bitsDamageType )
 	// Use the thrower's position as the reported position
 	Vector vecReported = GetThrower() ? GetThrower()->GetAbsOrigin() : vec3_origin;
 
-	CTakeDamageInfo info( this, GetThrower(), GetBlastForce(), GetAbsOrigin(), m_flDamage, bitsDamageType, 0, &vecReported );
+	CTakeDamageInfo info( this, GetThrower(), m_hLauncher, GetBlastForce(), GetAbsOrigin(), m_flDamage, bitsDamageType, 0, &vecReported );
 
 	float flRadius = GetDamageRadius();
 

--- a/src/game/shared/tf/tf_weaponbase_grenadeproj.h
+++ b/src/game/shared/tf/tf_weaponbase_grenadeproj.h
@@ -50,6 +50,7 @@ public:
 	virtual int			GetDamageType();
 
 	CNetworkVar( int, m_iDeflected );
+	CNetworkHandle( CBaseEntity, m_hLauncher );
 	CNetworkHandle( CBaseEntity, m_hDeflectOwner );
 
 private:
@@ -100,6 +101,8 @@ public:
 
 	bool					UseImpactNormal()							{ return m_bUseImpactNormal; }
 	const Vector			&GetImpactNormal( void ) const				{ return m_vecImpactNormal; }
+
+	virtual void			SetLauncher( CBaseEntity *pLauncher ) { m_hLauncher = pLauncher; }
 
 	virtual bool			IsDeflectable() { return true; }
 	virtual void			Deflected( CBaseEntity *pDeflectedBy, Vector &vecDir );

--- a/src/game/shared/tf/tf_weaponbase_gun.cpp
+++ b/src/game/shared/tf/tf_weaponbase_gun.cpp
@@ -437,6 +437,7 @@ CBaseEntity *CTFWeaponBaseGun::FireRocket( CTFPlayer *pPlayer )
 	{
 		pProjectile->SetCritical( IsCurrentAttackACrit() );
 		pProjectile->SetDamage( GetProjectileDamage() );
+		pProjectile->SetLauncher( this );
 	}
 	return pProjectile;
 
@@ -523,6 +524,7 @@ CBaseEntity *CTFWeaponBaseGun::FirePipeBomb( CTFPlayer *pPlayer, bool bRemoteDet
 	if ( pProjectile )
 	{
 		pProjectile->SetCritical( IsCurrentAttackACrit() );
+		pProjectile->SetLauncher( this );
 	}
 	return pProjectile;
 
@@ -553,6 +555,7 @@ CBaseEntity *CTFWeaponBaseGun::FireFlare(CTFPlayer *pPlayer)
 	{
 		pProjectile->SetCritical( IsCurrentAttackACrit() );
 		pProjectile->SetDamage( GetProjectileDamage() );
+		pProjectile->SetLauncher( this );
 	}
 	return pProjectile;
 #endif

--- a/src/game/shared/tf/tf_weaponbase_melee.cpp
+++ b/src/game/shared/tf/tf_weaponbase_melee.cpp
@@ -368,12 +368,12 @@ bool CTFWeaponBaseMelee::CalcIsAttackCriticalHelper( void )
 	if ( !pPlayer )
 		return false;
 
-	int iShouldCrit = tf_weapon_criticals_melee.GetInt();
+	int nCvarValue = tf_weapon_criticals_melee.GetInt();
 
-	if ( iShouldCrit == 0 )
+	if ( nCvarValue == 0 )
 		return false;
 
-	if ( iShouldCrit == 1 && !tf_weapon_criticals.GetBool() )
+	if ( nCvarValue == 1 && !tf_weapon_criticals.GetBool() )
 		return false;
 
 	float flPlayerCritMult = pPlayer->GetCritMult();

--- a/src/game/shared/tf/tf_weaponbase_rocket.cpp
+++ b/src/game/shared/tf/tf_weaponbase_rocket.cpp
@@ -336,7 +336,7 @@ void CTFBaseRocket::Explode( trace_t *pTrace, CBaseEntity *pOther )
 		pAttacker = pScorerInterface->GetScorer();
 	}
 
-	CTakeDamageInfo info( this, pAttacker, vec3_origin, vecOrigin, GetDamage(), GetDamageType() );
+	CTakeDamageInfo info( this, pAttacker, m_hLauncher, vec3_origin, vecOrigin, GetDamage(), GetDamageType() );
 	float flRadius = GetRadius();
 	RadiusDamage( info, vecOrigin, flRadius, CLASS_NONE, NULL );
 


### PR DESCRIPTION
 * Ported actual gibbing behaviour from live TF2. Explosion gibs player if it's a crit or his health is brought down to -10 or lower.
 * Implemented usage of CTakeDamageInfo::m_hWeapon. Now we can detect which weapon was used to inflict afterburn and switching weapons no longer grants full damage ramp-up to rockets.