### PR TITLE
Reworked DM ammo system

### DIFF
--- a/src/game/client/tf/c_tf_dropped_weapon.cpp
+++ b/src/game/client/tf/c_tf_dropped_weapon.cpp
@@ -29,9 +29,14 @@ public:
 private:
 	CGlowObject *m_pGlowEffect;
 	bool m_bShouldGlow;
+
+	int m_iAmmo;
+	int m_iMaxAmmo;
 };
 
 IMPLEMENT_CLIENTCLASS_DT( C_TFDroppedWeapon, DT_TFDroppedWeapon, CTFDroppedWeapon )
+	RecvPropInt( RECVINFO( m_iAmmo ) ),
+	RecvPropInt( RECVINFO( m_iMaxAmmo ) ),
 END_RECV_TABLE()
 
 LINK_ENTITY_TO_CLASS( tf_dropped_weapon, C_TFDroppedWeapon );
@@ -100,7 +105,13 @@ void C_TFDroppedWeapon::UpdateGlowEffect()
 {
 	if ( !m_pGlowEffect )
 	{
-		m_pGlowEffect = new CGlowObject( this, Vector( 0.75f, 0.75f, 0.15f ), 1.0f, true, true );
+		float flRed = RemapValClamped( m_iAmmo, m_iMaxAmmo / 2, m_iMaxAmmo, 0.75f, 0.15f );
+		float flGreen = RemapValClamped( m_iAmmo, 0, m_iMaxAmmo / 2, 0.15f, 0.75f );
+		float flBlue = 0.15f;
+		Vector vecColor = Vector( flRed, flGreen, flBlue );
+		float flAlpha = RemapValClamped( m_iAmmo, 0, m_iMaxAmmo, 0.25f, 1.0f );
+
+		m_pGlowEffect = new CGlowObject( this, vecColor, flAlpha, true, true );
 	}
 
 	if ( m_bShouldGlow )

--- a/src/game/server/tf/entity_ammopack.cpp
+++ b/src/game/server/tf/entity_ammopack.cpp
@@ -21,6 +21,10 @@ LINK_ENTITY_TO_CLASS( item_ammopack_full, CAmmoPack );
 LINK_ENTITY_TO_CLASS( item_ammopack_small, CAmmoPackSmall );
 LINK_ENTITY_TO_CLASS( item_ammopack_medium, CAmmoPackMedium );
 
+BEGIN_DATADESC( CAmmoPack )
+	DEFINE_INPUTFUNC( FIELD_VOID, "RoundSpawn", InputRoundSpawn ),
+END_DATADESC()
+
 //=============================================================================
 //
 // CTF AmmoPack functions.
@@ -35,6 +39,18 @@ void CAmmoPack::Spawn( void )
 	SetModel( GetPowerupModel() );
 
 	BaseClass::Spawn();
+}
+
+//-----------------------------------------------------------------------------
+// Purpose:
+//-----------------------------------------------------------------------------
+void CAmmoPack::InputRoundSpawn( inputdata_t &inputdata )
+{
+	if ( TFGameRules()->IsDeathmatch() )
+	{
+		Warning( "Ammo packs are not allowed in Deathmatch.\n" );
+		UTIL_Remove( this );
+	}
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/server/tf/entity_ammopack.h
+++ b/src/game/server/tf/entity_ammopack.h
@@ -23,10 +23,12 @@ class CAmmoPack : public CTFPowerup
 {
 public:
 	DECLARE_CLASS( CAmmoPack, CTFPowerup );
+	DECLARE_DATADESC();
 
 	void	Spawn( void );
 	void	Precache( void );
 	bool	MyTouch( CBasePlayer *pPlayer );
+	void	InputRoundSpawn( inputdata_t &inputdata );
 
 	powerupsize_t	GetPowerupSize( void ) { return POWERUP_FULL; }
 

--- a/src/game/server/tf/entity_weaponspawn.cpp
+++ b/src/game/server/tf/entity_weaponspawn.cpp
@@ -151,12 +151,15 @@ bool CWeaponSpawner::MyTouch(CBasePlayer *pPlayer)
 #ifndef DM_WEAPON_BUCKET
 		CTFWeaponBase *pWeapon = (CTFWeaponBase *)pTFPlayer->Weapon_GetSlot( m_pWeaponInfo->iSlot );
 		const char *pszWeaponName = WeaponIdToClassname( m_nWeaponID );
+		int iAmmoType = m_pWeaponInfo->iAmmoType;
+		int iMaxAmmo = m_pWeaponInfo->m_WeaponData[TF_WEAPON_PRIMARY_MODE].m_iMaxAmmo;
 
 		if ( pWeapon )
 		{
 			if ( pWeapon->GetWeaponID() == m_nWeaponID )
 			{
-				if ( pPlayer->GiveAmmo(999, m_pWeaponInfo->iAmmoType) )
+				// Weapon spawners give 50% ammo.
+				if ( pPlayer->GiveAmmo( ceil( iMaxAmmo * 0.5 ), iAmmoType ) )
 					bSuccess = true;
 			}
 			else if ( !(pTFPlayer->m_nButtons & IN_ATTACK) && 
@@ -196,6 +199,7 @@ bool CWeaponSpawner::MyTouch(CBasePlayer *pPlayer)
 		if ( !pWeapon )
 		{
 			pTFPlayer->GiveNamedItem( pszWeaponName );
+			pTFPlayer->SetAmmoCount( iMaxAmmo, iAmmoType );
 			pTFPlayer->m_Shared.SetDesiredWeaponIndex( TF_WEAPON_NONE );
 			bSuccess = true;
 		}

--- a/src/game/server/tf/entity_weaponspawn.cpp
+++ b/src/game/server/tf/entity_weaponspawn.cpp
@@ -198,10 +198,14 @@ bool CWeaponSpawner::MyTouch(CBasePlayer *pPlayer)
 
 		if ( !pWeapon )
 		{
-			pTFPlayer->GiveNamedItem( pszWeaponName );
-			pTFPlayer->SetAmmoCount( iMaxAmmo, iAmmoType );
-			pTFPlayer->m_Shared.SetDesiredWeaponIndex( TF_WEAPON_NONE );
-			bSuccess = true;
+			CTFWeaponBase *pNewWeapon = (CTFWeaponBase *)pTFPlayer->GiveNamedItem( pszWeaponName );
+			if ( pNewWeapon )
+			{
+				pNewWeapon->DefaultTouch( pPlayer );
+				pPlayer->SetAmmoCount( ceil( iMaxAmmo * 0.5f ), iAmmoType );
+				pTFPlayer->m_Shared.SetDesiredWeaponIndex( TF_WEAPON_NONE );
+				bSuccess = true;
+			}
 		}
 
 		if ( bSuccess )

--- a/src/game/server/tf/tf_dropped_weapon.cpp
+++ b/src/game/server/tf/tf_dropped_weapon.cpp
@@ -108,12 +108,14 @@ bool CTFDroppedWeapon::MyTouch( CBasePlayer *pPlayer )
 #ifndef DM_WEAPON_BUCKET
 		CTFWeaponBase *pWeapon = (CTFWeaponBase *)pTFPlayer->Weapon_GetSlot( GetTFWeaponInfo( m_nWeaponID )->iSlot );
 		const char *pszWeaponName = WeaponIdToClassname( m_nWeaponID );
+		int iAmmoType = GetTFWeaponInfo( m_nWeaponID )->iAmmoType;
 
 		if ( pWeapon )
 		{
 			if ( pWeapon->GetWeaponID() == m_nWeaponID )
 			{
-				if ( pTFPlayer->GiveAmmo( 999, GetTFWeaponInfo( m_nWeaponID )->iAmmoType ) )
+				// Give however many ammo we have
+				if ( pTFPlayer->GiveAmmo( m_iAmmo, GetTFWeaponInfo( m_nWeaponID )->iAmmoType ) )
 					bSuccess = true;
 			}
 			else if ( !(pTFPlayer->m_nButtons & IN_ATTACK) && ( pTFPlayer->m_nButtons & IN_USE ) )
@@ -146,7 +148,15 @@ bool CTFDroppedWeapon::MyTouch( CBasePlayer *pPlayer )
 
 		if ( !pWeapon )
 		{
-			pTFPlayer->GiveNamedItem( pszWeaponName );
+			CTFWeaponBase *pNewWeapon = (CTFWeaponBase *)pTFPlayer->GiveNamedItem( pszWeaponName );
+			pPlayer->SetAmmoCount( m_iAmmo, iAmmoType );
+			if ( pPlayer == GetOwnerEntity() )
+			{
+				// If this is the same guy who dropped it restore old clip size to avoid exploiting swapping
+				// weapons for faster reload.
+				pNewWeapon->m_iClip1 = m_iClip;
+			}
+
 			pTFPlayer->m_Shared.SetDesiredWeaponIndex( TF_WEAPON_NONE );
 			bSuccess = true;
 		}

--- a/src/game/server/tf/tf_dropped_weapon.h
+++ b/src/game/server/tf/tf_dropped_weapon.h
@@ -12,6 +12,7 @@
 #include "cbase.h"
 #include "tf_item.h"
 #include "items.h"
+#include "tf_weaponbase.h"
 
 class CTFDroppedWeapon : public CItem
 {
@@ -39,9 +40,11 @@ private:
 	float m_flCreationTime;
 	float m_flRemoveTime;
 	int m_nWeaponID;
+	CTFWeaponInfo *m_pWeaponInfo;
 	
 	int m_iClip;
-	int m_iAmmo;
+	CNetworkVar( int, m_iAmmo );
+	CNetworkVar( int, m_iMaxAmmo );
 };
 
 #endif

--- a/src/game/server/tf/tf_dropped_weapon.h
+++ b/src/game/server/tf/tf_dropped_weapon.h
@@ -29,6 +29,8 @@ public:
 	virtual void EndTouch( CBaseEntity *pOther );
 	void	RemovalThink( void );
 	float	GetCreationTime( void ) { return m_flCreationTime; }
+	void	SetClip( int iClip ) { m_iClip = iClip; }
+	void	SetAmmo( int iAmmo ) { m_iAmmo = iAmmo; }
 
 	static CTFDroppedWeapon *Create( const Vector &vecOrigin, const QAngle &vecAngles, CBaseEntity *pOwner, const char *pszModelName, unsigned int nWeaponID );
 
@@ -37,6 +39,9 @@ private:
 	float m_flCreationTime;
 	float m_flRemoveTime;
 	int m_nWeaponID;
+	
+	int m_iClip;
+	int m_iAmmo;
 };
 
 #endif

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -4440,6 +4440,12 @@ void CTFPlayer::DropWeapon( CTFWeaponBase *pWeapon, bool bKilled /*= false*/ )
 		( pWeapon->IsWeapon( TF_WEAPON_PISTOL ) || pWeapon->IsWeapon( TF_WEAPON_CROWBAR ) ) )
 		return;
 
+	int iClip = pWeapon->UsesClipsForAmmo1() ? pWeapon->Clip1() : -1;
+	int iAmmo = GetAmmoCount( pWeapon->GetPrimaryAmmoType() );
+
+	if ( iAmmo == 0 )
+		return;
+
 	// We need to find bones on the world model, so switch the weapon to it.
 	const char *pszWorldModel = pWeapon->GetWorldModel();
 	pWeapon->SetModel( pszWorldModel );
@@ -4456,9 +4462,6 @@ void CTFPlayer::DropWeapon( CTFWeaponBase *pWeapon, bool bKilled /*= false*/ )
 	if ( pDroppedWeapon )
 	{
 		// Give the dropped weapon entity our ammo.
-		int iClip = pWeapon->UsesClipsForAmmo1() ? pWeapon->Clip1() : -1;
-		int iAmmo = GetAmmoCount( pWeapon->GetPrimaryAmmoType() );
-
 		pDroppedWeapon->SetClip( iClip );
 		pDroppedWeapon->SetAmmo( iAmmo );
 

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -1158,6 +1158,12 @@ void CTFPlayer::GiveDefaultItems()
 		pWeaponEntity->Touch( this );
 	}
 
+	// Now that we've got weapons update our ammo counts since weapons may override max ammo.
+	for ( int iAmmo = 0; iAmmo < TF_AMMO_COUNT; ++iAmmo )
+	{
+		SetAmmoCount( GetMaxAmmo( iAmmo ), iAmmo );
+	}
+
 	if ( m_bRegenerating == false )
 	{
 		SetActiveWeapon( NULL );
@@ -3864,13 +3870,15 @@ void CTFPlayer::Event_Killed( const CTakeDamageInfo &info )
 	// Stop being invisible
 	m_Shared.RemoveCond( TF_COND_STEALTHED );
 
-	// Drop a pack with their leftover ammo
-	DropAmmoPack();
-
-	// Also drop our weapon in DM
 	if ( TFGameRules()->IsDeathmatch() )
 	{
+		// Drop our weapon in DM
 		DropWeapon( GetActiveTFWeapon(), true );
+	}
+	else
+	{
+		// Drop a pack with their leftover ammo
+		DropAmmoPack();
 	}
 
 	// If the player has a capture flag and was killed by another player, award that player a defense
@@ -4417,7 +4425,7 @@ void CTFPlayer::DropFakeWeapon( CTFWeaponBase *pWeapon )
 //-----------------------------------------------------------------------------
 // Purpose: Creates tf_dropped_weapon based on selected weapon
 //-----------------------------------------------------------------------------
-void CTFPlayer::DropWeapon( CTFWeaponBase *pWeapon, bool bRandomVel /*= false*/ )
+void CTFPlayer::DropWeapon( CTFWeaponBase *pWeapon, bool bKilled /*= false*/ )
 {
 	if ( !pWeapon ||
 		pWeapon->GetTFWpnData().m_bDontDrop ||
@@ -4447,9 +4455,19 @@ void CTFPlayer::DropWeapon( CTFWeaponBase *pWeapon, bool bRandomVel /*= false*/ 
 	Assert( pDroppedWeapon );
 	if ( pDroppedWeapon )
 	{
+		// Give the dropped weapon entity our ammo.
+		int iClip = pWeapon->UsesClipsForAmmo1() ? pWeapon->Clip1() : -1;
+		int iAmmo = GetAmmoCount( pWeapon->GetPrimaryAmmoType() );
+
+		pDroppedWeapon->SetClip( iClip );
+		pDroppedWeapon->SetAmmo( iAmmo );
+
 		// Randomize velocity if we dropped weapon upon being killed.
-		if ( bRandomVel )
+		if ( bKilled )
 		{
+			// Remove all of the player's ammo.
+			RemoveAllAmmo();
+
 			Vector vecRight, vecUp;
 			AngleVectors( EyeAngles(), NULL, &vecRight, &vecUp );
 
@@ -6538,11 +6556,11 @@ void CTFPlayer::DoTauntAttack( void )
 			if ( !pEntity || pEntity == this || !pEntity->IsAlive() || InSameTeam( pEntity ) )
 				continue;
 
-			Vector vecForceOrigin;
-			vecForceOrigin = WorldSpaceCenter();
-			vecForceOrigin += ( pEntity->WorldSpaceCenter() - vecForceOrigin ) * 0.75f;
+			Vector vecDamagePos;
+			vecDamagePos = WorldSpaceCenter();
+			vecDamagePos += ( pEntity->WorldSpaceCenter() - vecDamagePos ) * 0.75f;
 
-			CTakeDamageInfo info( this, this, GetActiveTFWeapon(), vecForce, vecForceOrigin, 500, DMG_IGNITE, TF_DMG_TAUNT_PYRO );
+			CTakeDamageInfo info( this, this, GetActiveTFWeapon(), vecForce, vecDamagePos, 500, DMG_IGNITE, TF_DMG_TAUNT_PYRO );
 			pEntity->TakeDamage( info );
 		}
 
@@ -6550,32 +6568,32 @@ void CTFPlayer::DoTauntAttack( void )
 	}
 	case TF_TAUNT_HEAVY:
 	{
-		Vector vecShotOrigin, vecForward, vecShotDir;
+		Vector vecSrc, vecShotDir, vecEnd;
 		QAngle angShot = EyeAngles();
-		vecShotOrigin = Weapon_ShootPosition();
-		AngleVectors( angShot, &vecForward );
-		vecShotDir = vecShotOrigin + vecForward * 500;
+		AngleVectors( angShot, &vecShotDir );
+		vecSrc = Weapon_ShootPosition();
+		vecEnd = vecSrc + vecShotDir * 500;
 
 		trace_t tr;
-		UTIL_TraceLine( vecShotOrigin, vecShotDir, MASK_SHOT, this, COLLISION_GROUP_PLAYER, &tr );
+		UTIL_TraceLine( vecSrc, vecEnd, MASK_SHOT, this, COLLISION_GROUP_PLAYER, &tr );
 
-		if ( tr.fraction < 1.0f && tr.m_pEnt )
+		if ( tr.fraction < 1.0f )
 		{
 			CBaseEntity *pEntity = tr.m_pEnt;
-
-			if ( pEntity->IsPlayer() && !InSameTeam( pEntity ) )
+			if ( pEntity && pEntity->IsPlayer() && !InSameTeam( pEntity ) )
 			{
-				Vector vecForce, vecForceOrigin;
+				Vector vecForce, vecDamagePos;
 				QAngle angForce( -45.0, angShot[YAW], 0.0 );
 				AngleVectors( angForce, &vecForce );
 				vecForce *= 25000.0f;
 
-				vecForceOrigin = tr.endpos;
+				vecDamagePos = tr.endpos;
 
-				CTakeDamageInfo info( this, this, GetActiveTFWeapon(), vecForce, vecForceOrigin, 500, DMG_BULLET, TF_DMG_TAUNT_HEAVY );
+				CTakeDamageInfo info( this, this, GetActiveTFWeapon(), vecForce, vecDamagePos, 500, DMG_BULLET, TF_DMG_TAUNT_HEAVY );
 				pEntity->TakeDamage( info );
 			}
 		}
+
 		break;
 	}
 	}

--- a/src/game/server/tf/tf_player.h
+++ b/src/game/server/tf/tf_player.h
@@ -277,7 +277,7 @@ public:
 
 	// Dropping Ammo
 	void DropAmmoPack( void );
-	void DropWeapon( CTFWeaponBase *pWeapon, bool bRandomVel = false );
+	void DropWeapon( CTFWeaponBase *pWeapon, bool bKilled = false );
 	void DropFakeWeapon( CTFWeaponBase *pWeapon );
 
 	bool CanDisguise( void );

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -231,8 +231,6 @@ void CTFWeaponBase::Spawn()
 // -----------------------------------------------------------------------------
 void CTFWeaponBase::FallInit( void )
 {
-	if (TFGameRules() && TFGameRules()->IsDeathmatch())
-		SetPickupTouch();
 }
 
 //-----------------------------------------------------------------------------
@@ -802,7 +800,7 @@ void CTFWeaponBase::PrimaryAttack( void )
 //-----------------------------------------------------------------------------
 void CTFWeaponBase::OnPickedUp(CBaseCombatCharacter *pNewOwner)
 {
-	BaseClass::OnPickedUp(pNewOwner);
+	BaseClass::OnPickedUp( pNewOwner );
 }
 
 

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -802,17 +802,6 @@ void CTFWeaponBase::PrimaryAttack( void )
 //-----------------------------------------------------------------------------
 void CTFWeaponBase::OnPickedUp(CBaseCombatCharacter *pNewOwner)
 {
-#ifdef GAME_DLL
-	CTFPlayer *pPlayer = ToTFPlayer(pNewOwner);
-	int iAmmoType = m_pWeaponInfo->iAmmoType;
-
-	if ( iAmmoType != -1 )
-	{
-		pPlayer->SetAmmoCount(1,iAmmoType);
-		pPlayer->GiveAmmo(pPlayer->GetMaxAmmo( iAmmoType ), iAmmoType);
-	}
-#endif
-
 	BaseClass::OnPickedUp(pNewOwner);
 }
 


### PR DESCRIPTION
* Ammo packs disabled
* Weapon spawners give 50% ammo rather than full ammo
* Killed players drop their active weapon which contains their leftover ammo for that weapon