### PR TITLE
Ported some cvars + Teleporter sapping behaviour

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -2683,7 +2683,7 @@ extern ConVar cl_sidespeed;
 void C_TFPlayer::AvoidPlayers( CUserCmd *pCmd )
 {
 	// Turn off the avoid player code.
-	if ( !tf_avoidteammates.GetBool() )
+	if ( !tf_avoidteammates.GetBool() || !tf_avoidteammates_pushaway.GetBool() )
 		return;
 
 	// Don't test if the player doesn't exist or is dead.
@@ -4046,8 +4046,12 @@ void C_TFPlayer::FireEvent( const Vector& origin, const QAngle& angles, int even
 // Shadows
 
 ConVar cl_blobbyshadows( "cl_blobbyshadows", "0", FCVAR_CLIENTDLL );
+extern ConVar tf2c_disable_player_shadows;
 ShadowType_t C_TFPlayer::ShadowCastType( void ) 
 {
+	if ( tf2c_disable_player_shadows.GetBool() )
+		return SHADOWS_NONE;
+
 	// Removed the GetPercentInvisible - should be taken care off in BindProxy now.
 	if ( !IsVisible() /*|| GetPercentInvisible() > 0.0f*/ )
 		return SHADOWS_NONE;
@@ -4139,6 +4143,7 @@ bool C_TFPlayer::IsNemesisOfLocalPlayer()
 	return false;
 }
 
+extern ConVar tf_tournament_hide_domination_icons;
 //-----------------------------------------------------------------------------
 // Purpose: Returns whether we should show the nemesis icon for this player
 //-----------------------------------------------------------------------------
@@ -4150,7 +4155,8 @@ bool C_TFPlayer::ShouldShowNemesisIcon()
 	{
 		bool bStealthed = m_Shared.InCond( TF_COND_STEALTHED );
 		bool bDisguised = m_Shared.InCond( TF_COND_DISGUISED );
-		if ( IsAlive() && !bStealthed && !bDisguised )
+		bool bTournamentHide = TFGameRules()->IsInTournamentMode() && tf_tournament_hide_domination_icons.GetBool();
+		if ( IsAlive() && !bStealthed && !bDisguised && !bTournamentHide )
 			return true;
 	}
 	return false;

--- a/src/game/server/tf/tf_obj.cpp
+++ b/src/game/server/tf/tf_obj.cpp
@@ -411,8 +411,12 @@ void CBaseObject::MakeCarriedObject( CTFPlayer *pPlayer )
 		// Save health amount building had before getting picked up. It will only heal back up to it.
 		m_iGoalHealth = GetHealth();
 
-		// Reset upgrade level. Building will automatically upgrade back once re-deployed.
+		// Save current upgrade level and reset it. Building will automatically upgrade back once re-deployed.
+		m_iGoalUpgradeLevel = GetUpgradeLevel();
 		m_iUpgradeLevel = 1;
+
+		// Reset placement rotation.
+		m_iDesiredBuildRotations = 0;
 
 		SetModel( GetPlacementModel() );
 
@@ -765,7 +769,6 @@ void CBaseObject::StartUpgrading(void)
 {
 	// Increase level
 	m_iUpgradeLevel++;
-	m_iGoalUpgradeLevel = max( m_iUpgradeLevel, m_iGoalUpgradeLevel );
 
 	// more health
 	if ( !IsRedeploying() )

--- a/src/game/server/tf/tf_obj.h
+++ b/src/game/server/tf/tf_obj.h
@@ -98,17 +98,17 @@ public:
 	virtual int		GetMaxHealthForCurrentLevel( void );
 	virtual void	StartPlacement( CTFPlayer *pPlayer );
 	void			StopPlacement( void );
-	bool			FindNearestBuildPoint( CBaseEntity *pEntity, CBasePlayer *pBuilder, float &flNearestPoint, Vector &vecNearestBuildPoint );
+	bool			FindNearestBuildPoint( CBaseEntity *pEntity, CBasePlayer *pBuilder, float &flNearestPoint, Vector &vecNearestBuildPoint, bool bIgnoreLOS = false );
 	bool			VerifyCorner( const Vector &vBottomCenter, float xOffset, float yOffset );
 	virtual float	GetNearbyObjectCheckRadius( void ) { return 30.0; }
 	bool			UpdatePlacement( void );
-	bool			UpdateAttachmentPlacement( void );
+	bool			UpdateAttachmentPlacement( CBaseObject *pObject = NULL );
 	bool			IsValidPlacement( void ) const;
 	bool			EstimateValidBuildPos( void );
 
 	bool			CalculatePlacementPos( void );
 	virtual bool	IsPlacementPosValid( void );
-	bool			FindSnapToBuildPos( void );
+	bool			FindSnapToBuildPos( CBaseObject *pObject = NULL );
 
 	void			ReattachChildren( void );
 	

--- a/src/game/server/tf/tf_obj_teleporter.cpp
+++ b/src/game/server/tf/tf_obj_teleporter.cpp
@@ -497,7 +497,6 @@ void CObjectTeleporter::CopyUpgradeStateToMatch( CObjectTeleporter *pMatch, bool
 	pObjToCopyTo->m_iMaxHealth = pObjToCopyFrom->m_iMaxHealth;
 	pObjToCopyTo->m_iUpgradeMetalRequired = pObjToCopyFrom->m_iUpgradeMetalRequired;
 	pObjToCopyTo->m_iUpgradeLevel = pObjToCopyFrom->m_iUpgradeLevel;
-	pObjToCopyTo->m_iGoalUpgradeLevel = pObjToCopyFrom->m_iGoalUpgradeLevel;
 
 	/**(pObjToCopyTo + 632) = *(this + 632);
 	*(pObjToCopyTo + 629) = *(this + 629);

--- a/src/game/server/tf/tf_obj_teleporter.cpp
+++ b/src/game/server/tf/tf_obj_teleporter.cpp
@@ -547,14 +547,15 @@ bool CObjectTeleporter::InputWrenchHit( CTFPlayer *pPlayer, CTFWrench *pWrench, 
 {
 	if ( HasSapper() && GetMatchingTeleporter() )
 	{
+		CObjectTeleporter *pMatch = GetMatchingTeleporter();
 		// do damage to any attached buildings
 		CTakeDamageInfo info( pPlayer, pPlayer, 65, DMG_CLUB, TF_DMG_WRENCH_FIX );
 
-		IHasBuildPoints *pBPInterface = dynamic_cast< IHasBuildPoints * >( GetMatchingTeleporter() );
+		IHasBuildPoints *pBPInterface = dynamic_cast< IHasBuildPoints * >( pMatch );
 		int iNumObjects = pBPInterface->GetNumObjectsOnMe();
 		for ( int iPoint=0; iPoint < iNumObjects; iPoint++ )
 		{
-			CBaseObject *pObject = GetBuildPointObject( iPoint );
+			CBaseObject *pObject = pMatch->GetBuildPointObject( iPoint );
 
 			if ( pObject && pObject->IsHostileUpgrade() )
 				pObject->TakeDamage( info );

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -89,7 +89,9 @@ ConVar tf_damage_range( "tf_damage_range", "0.5", FCVAR_DEVELOPMENTONLY );
 
 ConVar tf_max_voice_speak_delay( "tf_max_voice_speak_delay", "1.5", FCVAR_NOTIFY, "Max time after a voice command until player can do another one" );
 
-ConVar tf_allow_player_use( "tf_allow_player_use", "0", FCVAR_PROTECTED, "Allow players to execute + use while playing" );
+ConVar tf_allow_player_use( "tf_allow_player_use", "0", FCVAR_NOTIFY, "Allow players to execute + use while playing." );
+
+ConVar tf_allow_sliding_taunt( "tf_allow_sliding_taunt", "0", 0, "Allow player to slide for a bit after taunting." );
 
 extern ConVar spec_freeze_time;
 extern ConVar spec_freeze_traveltime;
@@ -5919,7 +5921,7 @@ void CTFPlayer::RemoveTeleportEffect( void )
 //-----------------------------------------------------------------------------
 void CTFPlayer::PlayerUse( void )
 {
-	if ( tf_allow_player_use.GetBool() || TFGameRules()->IsDeathmatch() || IsInCommentaryMode() )
+	if ( tf_allow_player_use.GetBool() || IsInCommentaryMode() )
 		BaseClass::PlayerUse();
 }
 
@@ -6607,7 +6609,10 @@ void CTFPlayer::Taunt( void )
 		m_angTauntCamera = EyeAngles();
 
 		// Slam velocity to zero.
-		SetAbsVelocity( vec3_origin );
+		if ( !tf_allow_sliding_taunt.GetBool() )
+		{
+			SetAbsVelocity( vec3_origin );
+		}
 
 		// Setup a taunt attack if necessary.
 		if ( Q_stricmp( szResponse, "scenes/player/pyro/low/taunt02.vcd" ) == 0 )

--- a/src/game/shared/tf/tf_gamemovement.cpp
+++ b/src/game/shared/tf/tf_gamemovement.cpp
@@ -32,9 +32,11 @@
 ConVar	tf_maxspeed( "tf_maxspeed", "400", FCVAR_NOTIFY | FCVAR_REPLICATED | FCVAR_CHEAT  | FCVAR_DEVELOPMENTONLY);
 ConVar	tf_showspeed( "tf_showspeed", "0", FCVAR_REPLICATED | FCVAR_DEVELOPMENTONLY );
 ConVar	tf_avoidteammates( "tf_avoidteammates", "1", FCVAR_REPLICATED | FCVAR_CHEAT | FCVAR_DEVELOPMENTONLY );
+ConVar	tf_avoidteammates_pushaway( "tf_avoidteammates_pushaway", "1", FCVAR_REPLICATED, "Whether or not teammates push each other away when occupying the same space" );
 ConVar  tf_solidobjects( "tf_solidobjects", "1", FCVAR_REPLICATED | FCVAR_CHEAT | FCVAR_DEVELOPMENTONLY );
 ConVar	tf_clamp_back_speed( "tf_clamp_back_speed", "0.9", FCVAR_REPLICATED | FCVAR_DEVELOPMENTONLY );
 ConVar  tf_clamp_back_speed_min( "tf_clamp_back_speed_min", "100", FCVAR_REPLICATED | FCVAR_DEVELOPMENTONLY );
+ConVar	tf_clamp_airducks( "tf_clamp_airducks", "1", FCVAR_REPLICATED );
 
 ConVar	tf2c_bunnyjump_max_speed_factor("tf2c_bunnyjump_max_speed_factor", "1.2", FCVAR_REPLICATED);
 ConVar  tf2c_autojump("tf2c_autojump", "0", FCVAR_REPLICATED, "Automatically jump while holding the jump button down");
@@ -47,6 +49,8 @@ ConVar  tf2c_groundspeed_cap("tf2c_groundspeed_cap", "1", FCVAR_REPLICATED, "Tog
 #define TF_WATERJUMP_UP       300
 //ConVar	tf_waterjump_up( "tf_waterjump_up", "300", FCVAR_REPLICATED | FCVAR_CHEAT | FCVAR_DEVELOPMENTONLY );
 //ConVar	tf_waterjump_forward( "tf_waterjump_forward", "30", FCVAR_REPLICATED | FCVAR_CHEAT | FCVAR_DEVELOPMENTONLY );
+
+#define TF_MAX_AIR_DUCKS 2
 
 class CTFGameMovement : public CGameMovement
 {
@@ -1205,7 +1209,160 @@ void CTFGameMovement::Duck( void )
 		mv->m_nButtons &= ~IN_DUCK;
 	}
 
-	BaseClass::Duck();
+	int buttonsChanged = ( mv->m_nOldButtons ^ mv->m_nButtons );	// These buttons have changed this frame
+	int buttonsPressed = buttonsChanged & mv->m_nButtons;			// The changed ones still down are "pressed"
+	int buttonsReleased = buttonsChanged & mv->m_nOldButtons;		// The changed ones which were previously down are "released"
+
+	// Check to see if we are in the air.
+	bool bInAir = ( player->GetGroundEntity() == NULL );
+	bool bInDuck = ( player->GetFlags() & FL_DUCKING ) ? true : false;
+
+	// If player is over air ducks limit he can't air duck again until he lands.
+	bool bCanAirDuck = !tf_clamp_airducks.GetBool() || m_pTFPlayer->m_Shared.GetAirDucks() < TF_MAX_AIR_DUCKS;
+
+	if ( mv->m_nButtons & IN_DUCK )
+	{
+		mv->m_nOldButtons |= IN_DUCK;
+	}
+	else
+	{
+		mv->m_nOldButtons &= ~IN_DUCK;
+	}
+
+	// Handle death.
+	if ( IsDead() )
+		return;
+
+	// Slow down ducked players.
+	HandleDuckingSpeedCrop();
+
+	// If the player is holding down the duck button, the player is in duck transition, ducking, or duck-jumping.
+	if ( ( mv->m_nButtons & IN_DUCK ) || player->m_Local.m_bDucking || bInDuck )
+	{
+		// DUCK
+		if ( ( mv->m_nButtons & IN_DUCK ) )
+		{
+			// Have the duck button pressed, but the player currently isn't in the duck position.
+			if ( ( buttonsPressed & IN_DUCK ) && !bInDuck && ( !bInAir || bCanAirDuck ) )
+			{
+				player->m_Local.m_flDucktime = GAMEMOVEMENT_DUCK_TIME;
+				player->m_Local.m_bDucking = true;
+			}
+
+			// The player is in duck transition and not duck-jumping.
+			if ( player->m_Local.m_bDucking )
+			{
+				float flDuckMilliseconds = MAX( 0.0f, GAMEMOVEMENT_DUCK_TIME - (float)player->m_Local.m_flDucktime );
+				float flDuckSeconds = flDuckMilliseconds * 0.001f;
+
+				// Finish in duck transition when transition time is over, in "duck", in air.
+				if ( ( flDuckSeconds > TIME_TO_DUCK ) || bInDuck || bInAir )
+				{
+					FinishDuck();
+
+					if ( bInAir && m_pTFPlayer->m_Shared.GetAirDucks() < TF_MAX_AIR_DUCKS )
+					{
+						// Ducked in mid-air, increment air ducks count.
+						m_pTFPlayer->m_Shared.IncrementAirDucks();
+					}
+				}
+				else
+				{
+					// Calc parametric time
+					float flDuckFraction = SimpleSpline( flDuckSeconds / TIME_TO_DUCK );
+					SetDuckedEyeOffset( flDuckFraction );
+				}
+			}
+		}
+		// UNDUCK (or attempt to...)
+		else
+		{
+			// Try to unduck unless automovement is not allowed
+			// NOTE: When not onground, you can always unduck
+			if ( player->m_Local.m_bAllowAutoMovement || bInAir || player->m_Local.m_bDucking )
+			{
+				// We released the duck button, we aren't in "duck" and we are not in the air - start unduck transition.
+				if ( ( buttonsReleased & IN_DUCK ) )
+				{
+					if ( bInDuck )
+					{
+						player->m_Local.m_flDucktime = GAMEMOVEMENT_DUCK_TIME;
+					}
+					else if ( player->m_Local.m_bDucking && !player->m_Local.m_bDucked )
+					{
+						// Invert time if release before fully ducked!!!
+						float unduckMilliseconds = 1000.0f * TIME_TO_UNDUCK;
+						float duckMilliseconds = 1000.0f * TIME_TO_DUCK;
+						float elapsedMilliseconds = GAMEMOVEMENT_DUCK_TIME - player->m_Local.m_flDucktime;
+
+						float fracDucked = elapsedMilliseconds / duckMilliseconds;
+						float remainingUnduckMilliseconds = fracDucked * unduckMilliseconds;
+
+						player->m_Local.m_flDucktime = GAMEMOVEMENT_DUCK_TIME - unduckMilliseconds + remainingUnduckMilliseconds;
+					}
+				}
+
+
+				// Check to see if we are capable of unducking.
+				if ( CanUnduck() )
+				{
+					// or unducking
+					if ( ( player->m_Local.m_bDucking || player->m_Local.m_bDucked ) )
+					{
+						float flDuckMilliseconds = MAX( 0.0f, GAMEMOVEMENT_DUCK_TIME - (float)player->m_Local.m_flDucktime );
+						float flDuckSeconds = flDuckMilliseconds * 0.001f;
+
+						// Finish ducking immediately if duck time is over or not on ground
+						if ( flDuckSeconds > TIME_TO_UNDUCK || bInAir )
+						{
+							FinishUnDuck();
+						}
+						else
+						{
+							// Calc parametric time
+							float flDuckFraction = SimpleSpline( 1.0f - ( flDuckSeconds / TIME_TO_UNDUCK ) );
+							SetDuckedEyeOffset( flDuckFraction );
+							player->m_Local.m_bDucking = true;
+						}
+					}
+				}
+				else
+				{
+					// Still under something where we can't unduck, so make sure we reset this timer so
+					//  that we'll unduck once we exit the tunnel, etc.
+					if ( player->m_Local.m_flDucktime != GAMEMOVEMENT_DUCK_TIME )
+					{
+						SetDuckedEyeOffset( 1.0f );
+						player->m_Local.m_flDucktime = GAMEMOVEMENT_DUCK_TIME;
+						player->m_Local.m_bDucked = true;
+						player->m_Local.m_bDucking = false;
+						player->AddFlag( FL_DUCKING );
+					}
+				}
+			}
+		}
+	}
+	// HACK: (jimd 5/25/2006) we have a reoccuring bug (#50063 in Tracker) where the player's
+	// view height gets left at the ducked height while the player is standing, but we haven't
+	// been  able to repro it to find the cause.  It may be fixed now due to a change I'm
+	// also making in UpdateDuckJumpEyeOffset but just in case, this code will sense the 
+	// problem and restore the eye to the proper position.  It doesn't smooth the transition,
+	// but it is preferable to leaving the player's view too low.
+	//
+	// If the player is still alive and not an observer, check to make sure that
+	// his view height is at the standing height.
+	else if ( !IsDead() && !player->IsObserver() && !player->IsInAVehicle() )
+	{
+		if ( ( player->m_Local.m_flDuckJumpTime == 0.0f ) && ( fabs( player->GetViewOffset().z - GetPlayerViewOffset( false ).z ) > 0.1 ) )
+		{
+			// we should rarely ever get here, so assert so a coder knows when it happens
+			Assert( 0 );
+			DevMsg( 1, "Restoring player view height\n" );
+
+			// set the eye height to the non-ducked height
+			SetDuckedEyeOffset( 0.0f );
+		}
+	}
 }
 
 void CTFGameMovement::HandleDuckingSpeedCrop( void )
@@ -1544,6 +1701,7 @@ void CTFGameMovement::SetGroundEntity( trace_t *pm )
 	if ( pm && pm->m_pEnt )
 	{
 		m_pTFPlayer->m_Shared.SetAirDash( false );
+		m_pTFPlayer->m_Shared.ResetAirDucks();
 	}
 }
 

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -88,6 +88,8 @@ extern ConVar tf_arena_max_streak;
 ConVar tf_caplinear( "tf_caplinear", "1", FCVAR_REPLICATED | FCVAR_DEVELOPMENTONLY, "If set to 1, teams must capture control points linearly." );
 ConVar tf_stalematechangeclasstime( "tf_stalematechangeclasstime", "20", FCVAR_REPLICATED | FCVAR_DEVELOPMENTONLY, "Amount of time that players are allowed to change class in stalemates." );
 ConVar tf_birthday( "tf_birthday", "0", FCVAR_NOTIFY | FCVAR_REPLICATED );
+
+// TF2C specific cvars.
 ConVar tf2c_falldamage_disablespread( "tf2c_falldamage_disablespread", "0", FCVAR_REPLICATED | FCVAR_NOTIFY, "Toggles random 20% fall damage spread." );
 ConVar tf2c_dm_spawnprotecttime( "tf2c_dm_spawnprotecttime", "5", FCVAR_REPLICATED | FCVAR_NOTIFY, "Time (in seconds) that the DM spawn protection lasts" );
 

--- a/src/game/shared/tf/tf_gamerules.h
+++ b/src/game/shared/tf/tf_gamerules.h
@@ -47,6 +47,7 @@
 #endif
 
 extern ConVar	tf_avoidteammates;
+extern ConVar	tf_avoidteammates_pushaway;
 
 extern ConVar	fraglimit;
 

--- a/src/game/shared/tf/tf_player_shared.h
+++ b/src/game/shared/tf/tf_player_shared.h
@@ -206,6 +206,9 @@ public:
 	void	SetJumping( bool bJumping );
 	bool    IsAirDashing( void ) { return m_bAirDash; }
 	void    SetAirDash( bool bAirDash );
+	int		GetAirDucks( void ) { return m_nAirDucked; }
+	void	IncrementAirDucks( void );
+	void	ResetAirDucks( void );
 
 	void	DebugPrintConditions( void );
 
@@ -353,6 +356,7 @@ private:
 
 	CNetworkVar( bool, m_bJumping );
 	CNetworkVar( bool, m_bAirDash );
+	CNetworkVar( int, m_nAirDucked );
 
 	CNetworkVar( float, m_flStealthNoAttackExpire );
 	CNetworkVar( float, m_flStealthNextChangeTime );

--- a/src/game/shared/tf/tf_projectile_flare.cpp
+++ b/src/game/shared/tf/tf_projectile_flare.cpp
@@ -81,6 +81,8 @@ void CTFProjectile_Flare::Spawn()
 {
 	SetModel( TF_WEAPON_FLARE_MODEL );
 	BaseClass::Spawn();
+	SetMoveType( MOVETYPE_FLYGRAVITY, MOVECOLLIDE_FLY_CUSTOM );
+	SetGravity( 0.3f );
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/shared/tf/tf_weapon_flamethrower.cpp
+++ b/src/game/shared/tf/tf_weapon_flamethrower.cpp
@@ -472,6 +472,7 @@ void CTFFlameThrower::SecondaryAttack()
 	}
 
 #ifdef CLIENT_DLL
+	StopFlame();
 #endif
 
 	m_iWeaponState = FT_STATE_AIRBLASTING;

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -752,6 +752,7 @@ bool CTFWeaponBase::Deploy( void )
 #endif
 
 	float flOriginalPrimaryAttack = m_flNextPrimaryAttack;
+	float flOriginalSecondaryAttack = m_flNextSecondaryAttack;
 
 	bool bDeploy = BaseClass::Deploy();
 
@@ -766,6 +767,7 @@ bool CTFWeaponBase::Deploy( void )
 		// people exploiting weapon switches to allow weapons to fire faster.
 		float flDeployTime = 0.67;
 		m_flNextPrimaryAttack = max( flOriginalPrimaryAttack, gpGlobals->curtime + flDeployTime );
+		m_flNextSecondaryAttack = max( flOriginalSecondaryAttack, gpGlobals->curtime + flDeployTime );
 
 		CTFPlayer *pPlayer = ToTFPlayer( GetOwner() );
 		if (!pPlayer)

--- a/src/game/shared/tf/tf_weaponbase_gun.cpp
+++ b/src/game/shared/tf/tf_weaponbase_gun.cpp
@@ -297,7 +297,7 @@ public:
 //-----------------------------------------------------------------------------
 // Purpose: Return angles for a projectile reflected by airblast
 //-----------------------------------------------------------------------------
-void CTFWeaponBaseGun::GetProjectileReflectSetup( CTFPlayer *pPlayer, Vector vecPos, QAngle *angForward, bool bHitTeammates /* = true */ )
+void CTFWeaponBaseGun::GetProjectileReflectSetup( CTFPlayer *pPlayer, const Vector &vecPos, Vector *vecDeflect, bool bHitTeammates /* = true */ )
 {
 	Vector vecForward, vecRight, vecUp;
 	AngleVectors( pPlayer->EyeAngles(), &vecForward, &vecRight, &vecUp );
@@ -321,19 +321,21 @@ void CTFWeaponBaseGun::GetProjectileReflectSetup( CTFPlayer *pPlayer, Vector vec
 		UTIL_TraceLine( vecShootPos, endPos, MASK_SOLID, &filter, &tr );
 	}
 
-	// VecPos is projectile's current position. Use that to find angles.
+	// vecPos is projectile's current position. Use that to find angles.
 
 	// Find angles that will get us to our desired end point
 	// Only use the trace end if it wasn't too close, which results
 	// in visually bizarre forward angles
 	if ( tr.fraction > 0.1 )
 	{
-		VectorAngles( tr.endpos - vecPos, *angForward );
+		*vecDeflect = tr.endpos - vecPos;
 	}
 	else
 	{
-		VectorAngles( endPos - vecPos, *angForward );
+		*vecDeflect = endPos - vecPos;
 	}
+
+	VectorNormalize( *vecDeflect );
 }
 
 //-----------------------------------------------------------------------------
@@ -371,7 +373,7 @@ void CTFWeaponBaseGun::GetProjectileFireSetup( CTFPlayer *pPlayer, Vector vecOff
 	if ( pPlayer )
 	{
 		C_TFPlayer *pLocalPlayer = C_TFPlayer::GetLocalTFPlayer();
-		if ( pLocalPlayer != pPlayer || ::input->CAM_IsThirdPerson() )
+		if ( pLocalPlayer != pPlayer || C_BasePlayer::ShouldDrawLocalPlayer() )
 		{
 			if ( pPlayer->GetActiveWeapon() )
 			{

--- a/src/game/shared/tf/tf_weaponbase_gun.h
+++ b/src/game/shared/tf/tf_weaponbase_gun.h
@@ -50,7 +50,7 @@ public:
 
 	virtual CBaseEntity *FireProjectile( CTFPlayer *pPlayer );
 	void				GetProjectileFireSetup( CTFPlayer *pPlayer, Vector vecOffset, Vector *vecSrc, QAngle *angForward, bool bHitTeammates = true );
-	void				GetProjectileReflectSetup( CTFPlayer *pPlayer, Vector vecPos, QAngle *angForward, bool bHitTeammates = true );
+	void				GetProjectileReflectSetup( CTFPlayer *pPlayer, const Vector &vecPos, Vector *vecDeflect, bool bHitTeammates = true );
 
 	void FireBullet( CTFPlayer *pPlayer );
 	CBaseEntity *FireRocket( CTFPlayer *pPlayer );

--- a/src/game/shared/tf/tf_weaponbase_melee.cpp
+++ b/src/game/shared/tf/tf_weaponbase_melee.cpp
@@ -104,6 +104,17 @@ void CTFWeaponBaseMelee::Spawn()
 // -----------------------------------------------------------------------------
 // Purpose:
 // -----------------------------------------------------------------------------
+bool CTFWeaponBaseMelee::CanHolster( void ) const
+{
+	if ( GetTFPlayerOwner()->m_Shared.InCond( TF_COND_CANNOT_SWITCH_FROM_MELEE ) )
+		return false;
+
+	return BaseClass::CanHolster();
+}
+
+// -----------------------------------------------------------------------------
+// Purpose:
+// -----------------------------------------------------------------------------
 bool CTFWeaponBaseMelee::Holster( CBaseCombatWeapon *pSwitchingTo )
 {
 	m_flSmackTime = -1.0f;
@@ -111,9 +122,6 @@ bool CTFWeaponBaseMelee::Holster( CBaseCombatWeapon *pSwitchingTo )
 	{
 		GetPlayerOwner()->m_flNextAttack = gpGlobals->curtime + 0.5;
 	}
-
-	if ( GetTFPlayerOwner()->m_Shared.InCond( TF_COND_CANNOT_SWITCH_FROM_MELEE ) )
-		return false;
 		
 	return BaseClass::Holster( pSwitchingTo );
 }

--- a/src/game/shared/tf/tf_weaponbase_melee.h
+++ b/src/game/shared/tf/tf_weaponbase_melee.h
@@ -43,6 +43,7 @@ public:
 	virtual void	Spawn();
 	virtual void	PrimaryAttack();
 	virtual void	SecondaryAttack();
+	virtual bool	CanHolster( void ) const;
 	virtual bool	Holster( CBaseCombatWeapon *pSwitchingTo );
 	virtual int		GetWeaponID( void ) const						{ return TF_WEAPON_NONE; }
 	virtual bool	ShouldDrawCrosshair( void )						{ return true; }


### PR DESCRIPTION
* Ported the following cvars from live TF2:
 * tf_allow_sliding_taunt
 * tf_avoidteammates_pushaway
 * tf_tournament_hide_domination_icons
 * tf_clamp_airducks

* New cvar
 * tf2c_disable_player_shadows - Disables rendering of player shadows regardless of client's graphical settings.

* Applied gravity to flares. Matches live TF2.
* Sapping a teleporter now automatically saps another end.